### PR TITLE
インク消費サブがメインの場合のカウント漏れ

### DIFF
--- a/views/show/battle.tpl
+++ b/views/show/battle.tpl
@@ -1226,7 +1226,7 @@
                     (function($){
                       var base = window.getInkSaverSub(0, 0);
                       var value = window.gearAbilities.ink_saver_sub
-                        ? window.getInkSaverSub(window.gearAbilities.ink_saver_sub.count.sub, window.gearAbilities.ink_saver_sub.count.sub)
+                        ? window.getInkSaverSub(window.gearAbilities.ink_saver_sub.count.main, window.gearAbilities.ink_saver_sub.count.sub)
                         : base;
                       $('#gearstat-ink-save-sub').text(
                         (value * 100).toFixed(1) + '%'


### PR DESCRIPTION
インク効率アップ（サブ）がメインの場合、カウントできていませんでした。
https://stat.ink/u/deathmetalland/316532

Signed-off-by: Death <deathmetalland@gmail.com>