### PR TITLE
自分と仲間のスペシャル発動が区別できていれば仲間のスペシャルを薄く表示する

### DIFF
--- a/resources/flot-graph-icon/jquery.flot.icon.js
+++ b/resources/flot-graph-icon/jquery.flot.icon.js
@@ -57,6 +57,7 @@
                             var itemWidth = convertToImageDimension(item[2]);
                             var itemHeight = convertToImageDimension(item[3]);
                             var userData = item.length >= 5 ? item[4] : undefined;
+                            var decorator = item.length >= 6 ? item[5] : undefined;
 
                             var pos = plot.p2c({x:item[1], y:0});
                             var posLeft = plotOffset.left + (pos.left - itemWidth / 2);
@@ -101,6 +102,9 @@
                                 } else {
                                     $img.attr('title', x);
                                 }
+                            }
+                            if (typeof decorator === 'function') {
+                                decorator.call(item, $img);
                             }
                             $target.append($img);
                         }

--- a/views/show/battle.tpl
+++ b/views/show/battle.tpl
@@ -1028,6 +1028,12 @@
                     return 'rgb(' + rgb[0] + ',' + rgb[1] + ',' + rgb[2] + ')';
                   };
 
+                  var isIdentifiedWhoseSpecial = (function () {
+                    return window.battleEvents.filter(function (v) {
+                      return v.at && v.type === "special_weapon" && v.me;
+                    }).length > 0;
+                  })();
+
                   var iconData = window.battleEvents.filter(function(v){
                     if (!v.at) {
                       return false;
@@ -1036,10 +1042,14 @@
                       return true;
                     }
                     if (v.type === "special_weapon") {
-                      switch (v.special_weapon) {
-                        {{foreach $specials as $special}}case "{{$special.key|escape:javascript}}":{{/foreach}}return true;
-                        default:return false;
-                      }
+                      return (
+                        {{foreach $specials as $special}}
+                          {{if !$special@first}}
+                            ||
+                          {{/if}}
+                          (v.special_weapon === "{{$special.key|escape:javascript}}")
+                        {{/foreach}}
+                      );
                     }
                     return false;
                   }).map(function(v){
@@ -1069,7 +1079,19 @@
                         {{/foreach}}
                       };
                       return [
-                        window.graphIcon.specials[v.special_weapon].src, v.at, size, size, names[v.special_weapon]
+                        window.graphIcon.specials[v.special_weapon].src,
+                        v.at,
+                        size,
+                        size,
+                        names[v.special_weapon],
+                        function ($img) {
+                          var data = this;
+                          if (isIdentifiedWhoseSpecial) {
+                            $img.css({
+                              opacity: v.me ? 1.0 : 0.4,
+                            });
+                          }
+                        }
                       ];
                     } else if (v.type === "special_charged") {
                       return [


### PR DESCRIPTION
fix #91