### PR TITLE
ブキがわからない時にスペシャル時間が 0 秒と出る問題を修正

### DIFF
--- a/components/ability/effect/v020500.php
+++ b/components/ability/effect/v020500.php
@@ -98,6 +98,9 @@ class v020500 extends Base
             return null;
         }
         $defSec = $this->getSpecialDurationDefaultSec();
+        if ($defSec === null) {
+            return null;
+        }
         return (1 + $x) * $defSec;
     }
 


### PR DESCRIPTION
fix #123