### PR TITLE
Separate user's stats

### DIFF
--- a/migrations/m190410_143924_user_stat_gachi2.php
+++ b/migrations/m190410_143924_user_stat_gachi2.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * @copyright Copyright (C) 2015-2019 AIZAWA Hina
+ * @license https://github.com/fetus-hina/stat.ink/blob/master/LICENSE MIT
+ * @author AIZAWA Hina <hina@bouhime.com>
+ */
+declare(strict_types=1);
+
+use app\components\db\Migration;
+
+class m190410_143924_user_stat_gachi2 extends Migration
+{
+    public function safeUp()
+    {
+        $this->createTable('user_stat_gachi2', array_merge(
+            [
+                'user_id'   => $this->pkRef('user')->notNull(),
+                'battles'   => $this->bigInteger()->notNull()->defaultValue(0),
+                'win_ko'    => $this->bigInteger()->notNull()->defaultValue(0),
+                'lose_ko'   => $this->bigInteger()->notNUll()->defaultValue(0),
+                'win_time'  => $this->bigInteger()->notNull()->defaultValue(0),
+                'lose_time' => $this->bigInteger()->notNull()->defaultValue(0),
+                'win_unk'   => $this->bigInteger()->notNull()->defaultValue(0),
+                'lose_unk'  => $this->bigInteger()->notNull()->defaultValue(0),
+            ],
+            $this->statColumns('kill'),
+            $this->statColumns('death'),
+            $this->statColumns('assist'),
+            [
+                'updated_at' => $this->timestampTZ(0)->notNull(),
+                'PRIMARY KEY ([[user_id]])',
+            ],
+        ));
+    }
+
+    public function safeDown()
+    {
+        $this->dropTable('user_stat_gachi2');
+    }
+
+    private function statColumns(string $baseName): array
+    {
+        $bigint = $this->bigInteger()->null();
+        $int = $this->integer()->null();
+        $number = $this->double()->null();
+        return [
+            "have_{$baseName}" => $bigint,
+            "total_{$baseName}" => $bigint,
+            "total_{$baseName}_with_time" => $bigint,
+            "total_time_{$baseName}" => $bigint,
+            "min_{$baseName}" => $int,
+            "pct5_{$baseName}" => $number,
+            "q1_4_{$baseName}" => $number,
+            "median_{$baseName}" => $number,
+            "q3_4_{$baseName}" => $number,
+            "pct95_{$baseName}" => $number,
+            "max_{$baseName}" => $int,
+            "stddev_{$baseName}" => $number,
+        ];
+    }
+}

--- a/migrations/m190410_145415_user_stat_gachi2_init.php
+++ b/migrations/m190410_145415_user_stat_gachi2_init.php
@@ -1,0 +1,159 @@
+<?php
+/**
+ * @copyright Copyright (C) 2015-2019 AIZAWA Hina
+ * @license https://github.com/fetus-hina/stat.ink/blob/master/LICENSE MIT
+ * @author AIZAWA Hina <hina@bouhime.com>
+ */
+declare(strict_types=1);
+
+use app\components\db\Migration;
+use yii\db\Query;
+
+class m190410_145415_user_stat_gachi2_init extends Migration
+{
+    public function safeUp()
+    {
+        $query = $this->buildSelectQuery();
+        $sql = 'INSERT INTO user_stat_gachi2 ' . $query->createCommand()->rawSql;
+        $this->execute($sql);
+    }
+
+
+    public function safeDown()
+    {
+        $this->truncateTable('user_stat_gachi2');
+    }
+
+    private function buildSelectQuery(): Query
+    {
+        $select = (new Query())
+            ->from('battle2')
+            ->andWhere([
+                'lobby_id' => $this->getTargetLobbyId(),
+                'mode_id' => $this->getTargetModeId(),
+                'rule_id' => $this->getTargetRuleId(),
+            ])
+            ->groupBy(['user_id'])
+            ->select(array_merge(
+                [
+                    'user_id' => 'battle2.user_id',
+                    'battles' => 'COUNT(*)',
+                    'win_ko' => $this->winCount(true, true),
+                    'lose_ko' => $this->winCount(false, true),
+                    'win_time' => $this->winCount(true, false),
+                    'lose_time' => $this->winCount(false, false),
+                    'win_unk' => $this->winCount(true, null),
+                    'lose_unk' => $this->winCount(false, null),
+                ],
+                $this->stats('kill', '[[kill]]'),
+                $this->stats('death', '[[death]]'),
+                $this->stats('assist', '[[kill_or_assist]] - [[kill]]'),
+                [
+                    'updated_at' => sprintf("('%s')", date(DATE_ATOM, time())),
+                ],
+            ));
+        return $select;
+    }
+
+    private function winCount(bool $filterIsWin, ?bool $filterIsKO): string
+    {
+        $conds = [];
+        $conds[] = 'WHEN [[is_win]] IS NULL THEN 0';
+        $conds[] = ($filterIsWin)
+            ? 'WHEN [[is_win]] = FALSE THEN 0'
+            : 'WHEN [[is_win]] = TRUE THEN 0';
+        if ($filterIsKO === null) {
+            $conds[] = 'WHEN [[is_knockout]] IS NOT NULL THEN 0';
+        } else {
+            $conds[] = ($filterIsKO)
+                ? 'WHEN [[is_knockout]] = FALSE THEN 0'
+                : 'WHEN [[is_knockout]] = TRUE THEN 0';
+        }
+        $conds[] = 'ELSE 1';
+        return sprintf('SUM(CASE %s END)', implode(' ', $conds));
+    }
+
+    private function stats(string $baseName, string $column): array
+    {
+        return [
+            "have_{$baseName}" => sprintf(
+                'SUM(CASE WHEN %1$s IS NULL THEN 0 ELSE 1 END)',
+                $column
+            ),
+            "total_{$baseName}" => sprintf(
+                'SUM(CASE WHEN %1$s IS NULL THEN 0 ELSE %1$s END)',
+                $column
+            ),
+            "total_{$baseName}_with_time" => sprintf('SUM(CASE %s END)', implode(' ', [
+                sprintf('WHEN %1$s IS NULL THEN NULL', $column),
+                'WHEN [[start_at]] IS NULL OR [[end_at]] IS NULL THEN NULL',
+                'ELSE ' . $column,
+            ])),
+            "total_time_{$baseName}" => sprintf('SUM(CASE %s END)', implode(' ', [
+                sprintf('WHEN %1$s IS NULL THEN NULL', $column),
+                'WHEN [[start_at]] IS NULL OR [[end_at]] IS NULL THEN NULL',
+                sprintf('ELSE (%s - %s)', $this->unixT('[[end_at]]'), $this->unixT('[[start_at]]')),
+            ])),
+            "min_{$baseName}" => "MIN({$column})",
+            "pct5_{$baseName}" => $this->percentile('0.05', $column),
+            "q1_4_{$baseName}" => $this->percentile('0.25', $column),
+            "median_{$baseName}" => $this->percentile('0.5', $column),
+            "q3_4_{$baseName}" => $this->percentile('0.75', $column),
+            "pct95_{$baseName}" => $this->percentile('0.95', $column),
+            "max_{$baseName}" => "MAX({$column})",
+            "stddev_{$baseName}" => "STDDEV_POP({$column})",
+        ];
+    }
+
+    private function unixT(string $column): string
+    {
+        return sprintf('EXTRACT(EPOCH FROM %s)', $column);
+    }
+
+    private function percentile(string $pos, string $column): string
+    {
+        return "PERCENTILE_CONT({$pos}) WITHIN GROUP (ORDER BY {$column})";
+    }
+
+    private function getTargetLobbyId(): array
+    {
+        $select = (new Query())
+            ->select(['id'])
+            ->from('lobby2')
+            ->where(['key' => 'standard']);
+        return array_map(
+            function (array $row): int {
+                return (int)$row['id'];
+            },
+            $select->all()
+        );
+    }
+
+    private function getTargetModeId(): array
+    {
+        $select = (new Query())
+            ->select(['id'])
+            ->from('mode2')
+            ->where(['key' => 'gachi']);
+        return array_map(
+            function (array $row): int {
+                return (int)$row['id'];
+            },
+            $select->all()
+        );
+    }
+
+    private function getTargetRuleId()
+    {
+        $select = (new Query())
+            ->select(['id'])
+            ->from('rule2')
+            ->where(['key' => ['area', 'yagura', 'hoko', 'asari']]);
+        return array_map(
+            function (array $row): int {
+                return (int)$row['id'];
+            },
+            $select->all()
+        );
+    }
+}

--- a/migrations/m190411_074057_user_stat_league2.php
+++ b/migrations/m190411_074057_user_stat_league2.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * @copyright Copyright (C) 2015-2019 AIZAWA Hina
+ * @license https://github.com/fetus-hina/stat.ink/blob/master/LICENSE MIT
+ * @author AIZAWA Hina <hina@bouhime.com>
+ */
+declare(strict_types=1);
+
+use app\components\db\Migration;
+
+class m190411_074057_user_stat_league2 extends Migration
+{
+    public function safeUp()
+    {
+        $this->createTable('user_stat_league2', array_merge(
+            [
+                'user_id'   => $this->pkRef('user')->notNull(),
+                'battles'   => $this->bigInteger()->notNull()->defaultValue(0),
+                'win_ko'    => $this->bigInteger()->notNull()->defaultValue(0),
+                'lose_ko'   => $this->bigInteger()->notNUll()->defaultValue(0),
+                'win_time'  => $this->bigInteger()->notNull()->defaultValue(0),
+                'lose_time' => $this->bigInteger()->notNull()->defaultValue(0),
+                'win_unk'   => $this->bigInteger()->notNull()->defaultValue(0),
+                'lose_unk'  => $this->bigInteger()->notNull()->defaultValue(0),
+            ],
+            $this->statColumns('kill'),
+            $this->statColumns('death'),
+            $this->statColumns('assist'),
+            [
+                'updated_at' => $this->timestampTZ(0)->notNull(),
+                'PRIMARY KEY ([[user_id]])',
+            ],
+        ));
+    }
+
+    public function safeDown()
+    {
+        $this->dropTable('user_stat_league2');
+    }
+
+    private function statColumns(string $baseName): array
+    {
+        $bigint = $this->bigInteger()->null();
+        $int = $this->integer()->null();
+        $number = $this->double()->null();
+        return [
+            "have_{$baseName}" => $bigint,
+            "total_{$baseName}" => $bigint,
+            "total_{$baseName}_with_time" => $bigint,
+            "total_time_{$baseName}" => $bigint,
+            "min_{$baseName}" => $int,
+            "pct5_{$baseName}" => $number,
+            "q1_4_{$baseName}" => $number,
+            "median_{$baseName}" => $number,
+            "q3_4_{$baseName}" => $number,
+            "pct95_{$baseName}" => $number,
+            "max_{$baseName}" => $int,
+            "stddev_{$baseName}" => $number,
+        ];
+    }
+}

--- a/migrations/m190411_082844_user_stat_league2_init.php
+++ b/migrations/m190411_082844_user_stat_league2_init.php
@@ -1,0 +1,159 @@
+<?php
+/**
+ * @copyright Copyright (C) 2015-2019 AIZAWA Hina
+ * @license https://github.com/fetus-hina/stat.ink/blob/master/LICENSE MIT
+ * @author AIZAWA Hina <hina@bouhime.com>
+ */
+declare(strict_types=1);
+
+use app\components\db\Migration;
+use yii\db\Query;
+
+class m190411_082844_user_stat_league2_init extends Migration
+{
+    public function safeUp()
+    {
+        $query = $this->buildSelectQuery();
+        $sql = 'INSERT INTO user_stat_league2 ' . $query->createCommand()->rawSql;
+        $this->execute($sql);
+    }
+
+
+    public function safeDown()
+    {
+        $this->truncateTable('user_stat_league2');
+    }
+
+    private function buildSelectQuery(): Query
+    {
+        $select = (new Query())
+            ->from('battle2')
+            ->andWhere([
+                'lobby_id' => $this->getTargetLobbyId(),
+                'mode_id' => $this->getTargetModeId(),
+                'rule_id' => $this->getTargetRuleId(),
+            ])
+            ->groupBy(['user_id'])
+            ->select(array_merge(
+                [
+                    'user_id' => 'battle2.user_id',
+                    'battles' => 'COUNT(*)',
+                    'win_ko' => $this->winCount(true, true),
+                    'lose_ko' => $this->winCount(false, true),
+                    'win_time' => $this->winCount(true, false),
+                    'lose_time' => $this->winCount(false, false),
+                    'win_unk' => $this->winCount(true, null),
+                    'lose_unk' => $this->winCount(false, null),
+                ],
+                $this->stats('kill', '[[kill]]'),
+                $this->stats('death', '[[death]]'),
+                $this->stats('assist', '[[kill_or_assist]] - [[kill]]'),
+                [
+                    'updated_at' => sprintf("('%s')", date(DATE_ATOM, time())),
+                ],
+            ));
+        return $select;
+    }
+
+    private function winCount(bool $filterIsWin, ?bool $filterIsKO): string
+    {
+        $conds = [];
+        $conds[] = 'WHEN [[is_win]] IS NULL THEN 0';
+        $conds[] = ($filterIsWin)
+            ? 'WHEN [[is_win]] = FALSE THEN 0'
+            : 'WHEN [[is_win]] = TRUE THEN 0';
+        if ($filterIsKO === null) {
+            $conds[] = 'WHEN [[is_knockout]] IS NOT NULL THEN 0';
+        } else {
+            $conds[] = ($filterIsKO)
+                ? 'WHEN [[is_knockout]] = FALSE THEN 0'
+                : 'WHEN [[is_knockout]] = TRUE THEN 0';
+        }
+        $conds[] = 'ELSE 1';
+        return sprintf('SUM(CASE %s END)', implode(' ', $conds));
+    }
+
+    private function stats(string $baseName, string $column): array
+    {
+        return [
+            "have_{$baseName}" => sprintf(
+                'SUM(CASE WHEN %1$s IS NULL THEN 0 ELSE 1 END)',
+                $column
+            ),
+            "total_{$baseName}" => sprintf(
+                'SUM(CASE WHEN %1$s IS NULL THEN 0 ELSE %1$s END)',
+                $column
+            ),
+            "total_{$baseName}_with_time" => sprintf('SUM(CASE %s END)', implode(' ', [
+                sprintf('WHEN %1$s IS NULL THEN NULL', $column),
+                'WHEN [[start_at]] IS NULL OR [[end_at]] IS NULL THEN NULL',
+                'ELSE ' . $column,
+            ])),
+            "total_time_{$baseName}" => sprintf('SUM(CASE %s END)', implode(' ', [
+                sprintf('WHEN %1$s IS NULL THEN NULL', $column),
+                'WHEN [[start_at]] IS NULL OR [[end_at]] IS NULL THEN NULL',
+                sprintf('ELSE (%s - %s)', $this->unixT('[[end_at]]'), $this->unixT('[[start_at]]')),
+            ])),
+            "min_{$baseName}" => "MIN({$column})",
+            "pct5_{$baseName}" => $this->percentile('0.05', $column),
+            "q1_4_{$baseName}" => $this->percentile('0.25', $column),
+            "median_{$baseName}" => $this->percentile('0.5', $column),
+            "q3_4_{$baseName}" => $this->percentile('0.75', $column),
+            "pct95_{$baseName}" => $this->percentile('0.95', $column),
+            "max_{$baseName}" => "MAX({$column})",
+            "stddev_{$baseName}" => "STDDEV_POP({$column})",
+        ];
+    }
+
+    private function unixT(string $column): string
+    {
+        return sprintf('EXTRACT(EPOCH FROM %s)', $column);
+    }
+
+    private function percentile(string $pos, string $column): string
+    {
+        return "PERCENTILE_CONT({$pos}) WITHIN GROUP (ORDER BY {$column})";
+    }
+
+    private function getTargetLobbyId(): array
+    {
+        $select = (new Query())
+            ->select(['id'])
+            ->from('lobby2')
+            ->where(['key' => ['squad_2', 'squad_4']]);
+        return array_map(
+            function (array $row): int {
+                return (int)$row['id'];
+            },
+            $select->all()
+        );
+    }
+
+    private function getTargetModeId(): array
+    {
+        $select = (new Query())
+            ->select(['id'])
+            ->from('mode2')
+            ->where(['key' => 'gachi']);
+        return array_map(
+            function (array $row): int {
+                return (int)$row['id'];
+            },
+            $select->all()
+        );
+    }
+
+    private function getTargetRuleId()
+    {
+        $select = (new Query())
+            ->select(['id'])
+            ->from('rule2')
+            ->where(['key' => ['area', 'yagura', 'hoko', 'asari']]);
+        return array_map(
+            function (array $row): int {
+                return (int)$row['id'];
+            },
+            $select->all()
+        );
+    }
+}

--- a/models/UserStatGachi2.php
+++ b/models/UserStatGachi2.php
@@ -1,0 +1,228 @@
+<?php
+/**
+ * @copyright Copyright (C) 2015-2019 AIZAWA Hina
+ * @license https://github.com/fetus-hina/stat.ink/blob/master/LICENSE MIT
+ * @author AIZAWA Hina <hina@bouhime.com>
+ */
+
+declare(strict_types=1);
+
+namespace app\models;
+
+use Yii;
+use yii\db\ActiveQuery;
+use yii\db\ActiveRecord;
+
+/**
+ * This is the model class for table "user_stat_gachi2".
+ *
+ * @property integer $user_id
+ * @property integer $battles
+ * @property integer $win_ko
+ * @property integer $lose_ko
+ * @property integer $win_time
+ * @property integer $lose_time
+ * @property integer $win_unk
+ * @property integer $lose_unk
+ * @property integer $have_kill
+ * @property integer $total_kill
+ * @property integer $total_kill_with_time
+ * @property integer $total_time_kill
+ * @property integer $min_kill
+ * @property double $pct5_kill
+ * @property double $q1_4_kill
+ * @property double $median_kill
+ * @property double $q3_4_kill
+ * @property double $pct95_kill
+ * @property integer $max_kill
+ * @property double $stddev_kill
+ * @property integer $have_death
+ * @property integer $total_death
+ * @property integer $total_death_with_time
+ * @property integer $total_time_death
+ * @property integer $min_death
+ * @property double $pct5_death
+ * @property double $q1_4_death
+ * @property double $median_death
+ * @property double $q3_4_death
+ * @property double $pct95_death
+ * @property integer $max_death
+ * @property double $stddev_death
+ * @property integer $have_assist
+ * @property integer $total_assist
+ * @property integer $total_assist_with_time
+ * @property integer $total_time_assist
+ * @property integer $min_assist
+ * @property double $pct5_assist
+ * @property double $q1_4_assist
+ * @property double $median_assist
+ * @property double $q3_4_assist
+ * @property double $pct95_assist
+ * @property integer $max_assist
+ * @property double $stddev_assist
+ * @property string $updated_at
+ *
+ * @property User $user
+ */
+class UserStatGachi2 extends ActiveRecord
+{
+    public static function tableName()
+    {
+        return 'user_stat_gachi2';
+    }
+
+    public function rules()
+    {
+        return [
+            [['user_id', 'updated_at'], 'required'],
+            [
+                [
+                    'user_id',
+                    'battles',
+                    'win_ko',
+                    'lose_ko',
+                    'win_time',
+                    'lose_time',
+                    'win_unk',
+                    'lose_unk',
+                    'have_kill',
+                    'total_kill',
+                    'total_kill_with_time',
+                    'total_time_kill',
+                    'min_kill',
+                    'max_kill',
+                    'have_death',
+                    'total_death',
+                    'total_death_with_time',
+                    'total_time_death',
+                    'min_death',
+                    'max_death',
+                    'have_assist',
+                    'total_assist',
+                    'total_assist_with_time',
+                    'total_time_assist',
+                    'min_assist',
+                    'max_assist',
+                ],
+                'default',
+                'value' => null,
+            ],
+            [
+                [
+                    'user_id',
+                    'battles',
+                    'win_ko',
+                    'lose_ko',
+                    'win_time',
+                    'lose_time',
+                    'win_unk',
+                    'lose_unk',
+                    'have_kill',
+                    'total_kill',
+                    'total_kill_with_time',
+                    'total_time_kill',
+                    'min_kill',
+                    'max_kill',
+                    'have_death',
+                    'total_death',
+                    'total_death_with_time',
+                    'total_time_death',
+                    'min_death',
+                    'max_death',
+                    'have_assist',
+                    'total_assist',
+                    'total_assist_with_time',
+                    'total_time_assist',
+                    'min_assist',
+                    'max_assist',
+                ],
+                'integer',
+            ],
+            [
+                [
+                    'pct5_kill',
+                    'q1_4_kill',
+                    'median_kill',
+                    'q3_4_kill',
+                    'pct95_kill',
+                    'stddev_kill',
+                    'pct5_death',
+                    'q1_4_death',
+                    'median_death',
+                    'q3_4_death',
+                    'pct95_death',
+                    'stddev_death',
+                    'pct5_assist',
+                    'q1_4_assist',
+                    'median_assist',
+                    'q3_4_assist',
+                    'pct95_assist',
+                    'stddev_assist',
+                ],
+                'number',
+            ],
+            [['updated_at'], 'safe'],
+            [['user_id'], 'unique'],
+            [['user_id'], 'exist', 'skipOnError' => true,
+                'targetClass' => User::class,
+                'targetAttribute' => ['user_id' => 'id'],
+            ],
+        ];
+    }
+
+    public function attributeLabels()
+    {
+        return [
+            'user_id' => 'User ID',
+            'battles' => 'Battles',
+            'win_ko' => 'Win Ko',
+            'lose_ko' => 'Lose Ko',
+            'win_time' => 'Win Time',
+            'lose_time' => 'Lose Time',
+            'win_unk' => 'Win Unk',
+            'lose_unk' => 'Lose Unk',
+            'have_kill' => 'Have Kill',
+            'total_kill' => 'Total Kill',
+            'total_kill_with_time' => 'Total Kill With Time',
+            'total_time_kill' => 'Total Time Kill',
+            'min_kill' => 'Min Kill',
+            'pct5_kill' => 'Pct5 Kill',
+            'q1_4_kill' => 'Q1 4 Kill',
+            'median_kill' => 'Median Kill',
+            'q3_4_kill' => 'Q3 4 Kill',
+            'pct95_kill' => 'Pct95 Kill',
+            'max_kill' => 'Max Kill',
+            'stddev_kill' => 'Stddev Kill',
+            'have_death' => 'Have Death',
+            'total_death' => 'Total Death',
+            'total_death_with_time' => 'Total Death With Time',
+            'total_time_death' => 'Total Time Death',
+            'min_death' => 'Min Death',
+            'pct5_death' => 'Pct5 Death',
+            'q1_4_death' => 'Q1 4 Death',
+            'median_death' => 'Median Death',
+            'q3_4_death' => 'Q3 4 Death',
+            'pct95_death' => 'Pct95 Death',
+            'max_death' => 'Max Death',
+            'stddev_death' => 'Stddev Death',
+            'have_assist' => 'Have Assist',
+            'total_assist' => 'Total Assist',
+            'total_assist_with_time' => 'Total Assist With Time',
+            'total_time_assist' => 'Total Time Assist',
+            'min_assist' => 'Min Assist',
+            'pct5_assist' => 'Pct5 Assist',
+            'q1_4_assist' => 'Q1 4 Assist',
+            'median_assist' => 'Median Assist',
+            'q3_4_assist' => 'Q3 4 Assist',
+            'pct95_assist' => 'Pct95 Assist',
+            'max_assist' => 'Max Assist',
+            'stddev_assist' => 'Stddev Assist',
+            'updated_at' => 'Updated At',
+        ];
+    }
+
+    public function getUser(): ActiveQuery
+    {
+        return $this->hasOne(User::class, ['id' => 'user_id']);
+    }
+}

--- a/models/UserStatLeague2.php
+++ b/models/UserStatLeague2.php
@@ -1,0 +1,228 @@
+<?php
+/**
+ * @copyright Copyright (C) 2015-2019 AIZAWA Hina
+ * @license https://github.com/fetus-hina/stat.ink/blob/master/LICENSE MIT
+ * @author AIZAWA Hina <hina@bouhime.com>
+ */
+
+declare(strict_types=1);
+
+namespace app\models;
+
+use Yii;
+use yii\db\ActiveQuery;
+use yii\db\ActiveRecord;
+
+/**
+ * This is the model class for table "user_stat_league2".
+ *
+ * @property integer $user_id
+ * @property integer $battles
+ * @property integer $win_ko
+ * @property integer $lose_ko
+ * @property integer $win_time
+ * @property integer $lose_time
+ * @property integer $win_unk
+ * @property integer $lose_unk
+ * @property integer $have_kill
+ * @property integer $total_kill
+ * @property integer $total_kill_with_time
+ * @property integer $total_time_kill
+ * @property integer $min_kill
+ * @property double $pct5_kill
+ * @property double $q1_4_kill
+ * @property double $median_kill
+ * @property double $q3_4_kill
+ * @property double $pct95_kill
+ * @property integer $max_kill
+ * @property double $stddev_kill
+ * @property integer $have_death
+ * @property integer $total_death
+ * @property integer $total_death_with_time
+ * @property integer $total_time_death
+ * @property integer $min_death
+ * @property double $pct5_death
+ * @property double $q1_4_death
+ * @property double $median_death
+ * @property double $q3_4_death
+ * @property double $pct95_death
+ * @property integer $max_death
+ * @property double $stddev_death
+ * @property integer $have_assist
+ * @property integer $total_assist
+ * @property integer $total_assist_with_time
+ * @property integer $total_time_assist
+ * @property integer $min_assist
+ * @property double $pct5_assist
+ * @property double $q1_4_assist
+ * @property double $median_assist
+ * @property double $q3_4_assist
+ * @property double $pct95_assist
+ * @property integer $max_assist
+ * @property double $stddev_assist
+ * @property string $updated_at
+ *
+ * @property User $user
+ */
+class UserStatLeague2 extends ActiveRecord
+{
+    public static function tableName()
+    {
+        return 'user_stat_league2';
+    }
+
+    public function rules()
+    {
+        return [
+            [['user_id', 'updated_at'], 'required'],
+            [
+                [
+                    'user_id',
+                    'battles',
+                    'win_ko',
+                    'lose_ko',
+                    'win_time',
+                    'lose_time',
+                    'win_unk',
+                    'lose_unk',
+                    'have_kill',
+                    'total_kill',
+                    'total_kill_with_time',
+                    'total_time_kill',
+                    'min_kill',
+                    'max_kill',
+                    'have_death',
+                    'total_death',
+                    'total_death_with_time',
+                    'total_time_death',
+                    'min_death',
+                    'max_death',
+                    'have_assist',
+                    'total_assist',
+                    'total_assist_with_time',
+                    'total_time_assist',
+                    'min_assist',
+                    'max_assist',
+                ],
+                'default',
+                'value' => null,
+            ],
+            [
+                [
+                    'user_id',
+                    'battles',
+                    'win_ko',
+                    'lose_ko',
+                    'win_time',
+                    'lose_time',
+                    'win_unk',
+                    'lose_unk',
+                    'have_kill',
+                    'total_kill',
+                    'total_kill_with_time',
+                    'total_time_kill',
+                    'min_kill',
+                    'max_kill',
+                    'have_death',
+                    'total_death',
+                    'total_death_with_time',
+                    'total_time_death',
+                    'min_death',
+                    'max_death',
+                    'have_assist',
+                    'total_assist',
+                    'total_assist_with_time',
+                    'total_time_assist',
+                    'min_assist',
+                    'max_assist',
+                ],
+                'integer',
+            ],
+            [
+                [
+                    'pct5_kill',
+                    'q1_4_kill',
+                    'median_kill',
+                    'q3_4_kill',
+                    'pct95_kill',
+                    'stddev_kill',
+                    'pct5_death',
+                    'q1_4_death',
+                    'median_death',
+                    'q3_4_death',
+                    'pct95_death',
+                    'stddev_death',
+                    'pct5_assist',
+                    'q1_4_assist',
+                    'median_assist',
+                    'q3_4_assist',
+                    'pct95_assist',
+                    'stddev_assist',
+                ],
+                'number',
+            ],
+            [['updated_at'], 'safe'],
+            [['user_id'], 'unique'],
+            [['user_id'], 'exist', 'skipOnError' => true,
+                'targetClass' => User::class,
+                'targetAttribute' => ['user_id' => 'id'],
+            ],
+        ];
+    }
+
+    public function attributeLabels()
+    {
+        return [
+            'user_id' => 'User ID',
+            'battles' => 'Battles',
+            'win_ko' => 'Win Ko',
+            'lose_ko' => 'Lose Ko',
+            'win_time' => 'Win Time',
+            'lose_time' => 'Lose Time',
+            'win_unk' => 'Win Unk',
+            'lose_unk' => 'Lose Unk',
+            'have_kill' => 'Have Kill',
+            'total_kill' => 'Total Kill',
+            'total_kill_with_time' => 'Total Kill With Time',
+            'total_time_kill' => 'Total Time Kill',
+            'min_kill' => 'Min Kill',
+            'pct5_kill' => 'Pct5 Kill',
+            'q1_4_kill' => 'Q1 4 Kill',
+            'median_kill' => 'Median Kill',
+            'q3_4_kill' => 'Q3 4 Kill',
+            'pct95_kill' => 'Pct95 Kill',
+            'max_kill' => 'Max Kill',
+            'stddev_kill' => 'Stddev Kill',
+            'have_death' => 'Have Death',
+            'total_death' => 'Total Death',
+            'total_death_with_time' => 'Total Death With Time',
+            'total_time_death' => 'Total Time Death',
+            'min_death' => 'Min Death',
+            'pct5_death' => 'Pct5 Death',
+            'q1_4_death' => 'Q1 4 Death',
+            'median_death' => 'Median Death',
+            'q3_4_death' => 'Q3 4 Death',
+            'pct95_death' => 'Pct95 Death',
+            'max_death' => 'Max Death',
+            'stddev_death' => 'Stddev Death',
+            'have_assist' => 'Have Assist',
+            'total_assist' => 'Total Assist',
+            'total_assist_with_time' => 'Total Assist With Time',
+            'total_time_assist' => 'Total Time Assist',
+            'min_assist' => 'Min Assist',
+            'pct5_assist' => 'Pct5 Assist',
+            'q1_4_assist' => 'Q1 4 Assist',
+            'median_assist' => 'Median Assist',
+            'q3_4_assist' => 'Q3 4 Assist',
+            'pct95_assist' => 'Pct95 Assist',
+            'max_assist' => 'Max Assist',
+            'stddev_assist' => 'Stddev Assist',
+            'updated_at' => 'Updated At',
+        ];
+    }
+
+    public function getUser(): ActiveQuery
+    {
+        return $this->hasOne(User::class, ['id' => 'user_id']);
+    }
+}


### PR DESCRIPTION
Replaces: #426
Resolve target: #403, #408 

- [ ] Auto update mechanism
- [ ] Create stats for Solo Ranked battles
  - [x] Totally _(Entirely? All of?)_ Ranked battles - <del>4d8bd2d</del> 1c96947
  - [ ] Per-mode(rule) - should support MAX, CURRENT rank / X Power
- [ ] Create stats for League battles 
  - [x] Totally League battles - <del>e580a9a</del> 6985fff
  - [ ] Per-mode(rule)- should support MAX 
- [ ] Create stats for Turf War
  - [ ] Totally Turf War battles
  - [ ] Per-lobby
    - [ ] Regular
     - [ ] Splatfest
       - [ ] Solo / Pro - should support Splatfest Power
       - [ ] Team / Normal - should support max. total clout?