### PR TITLE
Add Japanese calendar support

### DIFF
--- a/components/helpers/I18n.php
+++ b/components/helpers/I18n.php
@@ -33,9 +33,9 @@ class I18n
 
 
         $ret = [];
-        foreach (Language::find()->asArray()->all() as $lang) {
+        foreach (Language::find()->all() as $lang) {
             $newParams = array_merge(
-                [$route, '_lang_' => $lang['lang']],
+                [$route, '_lang_' => $lang->lang],
                 $params
             );
             $ret[] = Html::tag(
@@ -43,7 +43,7 @@ class I18n
                 '',
                 [
                     'rel' => 'alternate',
-                    'hreflang' => $lang['lang'],
+                    'hreflang' => $lang->languageId,
                     'href' => Url::to($newParams, true),
                 ]
             );

--- a/components/widgets/SalmonHazardHistory.php
+++ b/components/widgets/SalmonHazardHistory.php
@@ -71,7 +71,11 @@ class SalmonHazardHistory extends Widget
 
         // Japanese & Korean: 〇 ×
         // Other regions: ✓ ✗
-        $japaneseStyle = in_array(Yii::$app->language, ['ja-JP', 'ko-KR', 'ko-KP']);
+        $japaneseStyle = in_array(
+            preg_replace('/@.+$/', '', Yii::$app->language),
+            ['ja-JP', 'ko-KR', 'ko-KP'],
+            true
+        );
 
         // cleared
         $series2 = [

--- a/components/widgets/TimestampColumnWidget.php
+++ b/components/widgets/TimestampColumnWidget.php
@@ -28,10 +28,8 @@ class TimestampColumnWidget extends Widget
         parent::init();
 
         if (!$this->formatter) {
-            $this->formatter = Yii::createObject([
-                'class' => Formatter::class,
-                'nullDisplay' => '',
-            ]);
+            $this->formatter = clone Yii::$app->formatter;
+            $this->formatter->nullDisplay = '';
         } elseif (is_array($this->formatter)) {
             $this->formatter = Yii::createObject($this->formatter);
         }

--- a/migrations/m190417_164517_update_lang_for_japanese_era.php
+++ b/migrations/m190417_164517_update_lang_for_japanese_era.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * @copyright Copyright (C) 2015-2019 AIZAWA Hina
+ * @license https://github.com/fetus-hina/stat.ink/blob/master/LICENSE MIT
+ * @author AIZAWA Hina <hina@bouhime.com>
+ */
+declare(strict_types=1);
+
+use app\components\db\Migration;
+
+class m190417_164517_update_lang_for_japanese_era extends Migration
+{
+    public function safeUp()
+    {
+        $this->execute('ALTER TABLE {{language}} ' . implode(', ', [
+            'ALTER COLUMN [[lang]] TYPE VARCHAR(32)',
+            'ADD COLUMN [[di]] JSONB NULL',
+        ]));
+        $this->insert('language', [
+            'lang' => 'ja-JP@calendar=japanese',
+            'name' => '日本語（和暦）',
+            'name_en' => 'Japanese (Japanese Era)',
+            'support_level_id' => 1, // FULL
+            'di' => json_encode([
+                'formatter' => [
+                    'locale' => 'ja_JP@calendar=japanese',
+                    'calendar' => IntlDateFormatter::TRADITIONAL,
+                    'dateFormat' => 'Gy年MM月dd日',
+                    'datetimeFormat' => 'Gy年MM月dd日 HH時mm分ss秒',
+                    'timeFormat' => 'HH時mm分ss秒',
+                ],
+            ]),
+        ]);
+    }
+
+    public function safeDown()
+    {
+        $this->delete('language', ['lang' => 'ja-JP@calendar=japanese']);
+        $this->execute('ALTER TABLE {{language}} ' . implode(', ', [
+            'ALTER COLUMN [[lang]] ' . $this->string(5)->notNull()->unique(),
+            'DROP COLUMN [[di]]',
+        ]));
+    }
+}

--- a/models/Salmon2.php
+++ b/models/Salmon2.php
@@ -398,7 +398,7 @@ class Salmon2 extends ActiveRecord
         );
     }
 
-    public function getTeamTotalGoldenEggsPerWave(): array
+    public function getTeamTotalGoldenEggsPerWave(): ?array
     {
         if (!$this->waves) {
             return null;
@@ -437,7 +437,7 @@ class Salmon2 extends ActiveRecord
         );
     }
 
-    public function getTeamTotalPowerEggsPerWave(): array
+    public function getTeamTotalPowerEggsPerWave(): ?array
     {
         if (!$this->waves) {
             return null;

--- a/views/download-stats/_dl-langs.php
+++ b/views/download-stats/_dl-langs.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 use app\assets\DownloadsPageAsset;
 use app\models\Language;
 use hiqdev\assets\flagiconcss\FlagIconCssAsset;
@@ -15,7 +17,8 @@ $langs = Language::find()
   ->all();
 ?>
 <ul class="dl-langs">
-<?php foreach ($langs as $lang): ?>
+<?php foreach ($langs as $lang) { ?>
+<?php if ($lang['languageCharsets']) { ?>
   <li>
     <?= Html::tag(
       'span',
@@ -29,7 +32,7 @@ $langs = Language::find()
       ['class' => 'lang']
     ) . "\n" ?>
     <span class="charsets">
-<?php foreach ($lang['languageCharsets'] as $_charset): ?>
+<?php foreach ($lang['languageCharsets'] as $_charset) { ?>
 <?php $charset = $_charset['charset'] ?>
       <span class="charset">
         <?= Html::a(
@@ -49,7 +52,7 @@ $langs = Language::find()
           ]
         ) . "\n" ?>
       </span>
-<?php if ($charset['name'] === 'UTF-8'): ?>
+<?php if ($charset['name'] === 'UTF-8') { ?>
         <span class="charset">
           <?= Html::a(
             Html::encode($charset['name']) . '(BOM)',
@@ -64,7 +67,7 @@ $langs = Language::find()
             ]
           ) . "\n" ?>
         </span>
-<?php elseif ($charset['name'] === 'UTF-16LE'): ?>
+<?php } elseif ($charset['name'] === 'UTF-16LE') { ?>
         <span class="charset">
           <?= Html::a(
             Html::encode($charset['name']) . '(TSV)',
@@ -79,9 +82,10 @@ $langs = Language::find()
             ]
           ) . "\n" ?>
         </span>
-<?php endif ?>
-<?php endforeach ?>
+<?php } ?>
+<?php } ?>
     </span>
   </li>
-<?php endforeach ?>
+<?php } ?>
+<?php } ?>
 </ul>

--- a/views/layouts/main.php
+++ b/views/layouts/main.php
@@ -53,7 +53,7 @@ if ($_flashes) {
 ?>
 <?php $this->beginPage() ?>
 <!DOCTYPE html>
-<?= Html::beginTag('html', ['lang' => Yii::$app->language]) . "\n" ?>
+<?= Html::beginTag('html', ['lang' => preg_replace('/@.+$/', '', Yii::$app->language)]) . "\n" ?>
   <head>
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/views/salmon/view/_detail.php
+++ b/views/salmon/view/_detail.php
@@ -14,10 +14,8 @@ use yii\helpers\Html;
 use yii\helpers\Url;
 use yii\widgets\DetailView;
 
-$formatter = Yii::createObject([
-  'class' => Formatter::class,
-  'nullDisplay' => '',
-]);
+$formatter = clone Yii::$app->formatter;
+$formatter->nullDisplay = '';
 
 $widget = Yii::createObject([
   'class' => DetailView::class,

--- a/views/show-v2/_battle_details.php
+++ b/views/show-v2/_battle_details.php
@@ -710,25 +710,6 @@ $this->registerCss('#battle .progress{margin-bottom:0}');
           return null;
         }
         return null;
-        // <tr>
-        //   <th>{{'Cause of Death'|translate:'app'|escape}}</th>
-        //   <td>
-        //     <table>
-        //       <tbody>
-        //         {{foreach $deathReasons as $deathReason}}
-        //           <tr>
-        //             <td>{{$deathReason->reason->translatedName|default:'?'|escape}}</td>
-        //             <td style="padding:0 10px">:</td>
-        //             <td>
-        //               {{$params = ['n' => $deathReason->count, 'nFormatted' => $app->formatter->asDecimal($deathReason->count)]}}
-        //               {{"{nFormatted} {n, plural, =1{time} other{times}}"|translate:'app':$params|escape}}
-        //             </td>
-        //           </tr>
-        //         {{/foreach}}
-        //       </tbody>
-        //     </table>
-        //   </td>
-        // </tr>
       },
       // }}}
     ],
@@ -848,6 +829,7 @@ $this->registerCss('#battle .progress{margin-bottom:0}');
           TimestampColumnWidget::widget([
             'value' => $model->start_at,
             'showRelative' => true,
+            'formatter' => $fmt,
           ]),
           $periodFrom && $periodTo
             ? Html::a(

--- a/views/site/index.php
+++ b/views/site/index.php
@@ -39,7 +39,7 @@ PaintballAsset::register($this);
     </div>
   </div>
   <?= HappyNewYearWidget::widget() . "\n" ?>
-<?php if (Yii::$app->language === 'ja-JP'): ?>
+<?php if (substr(Yii::$app->language, 0, 2) === 'ja'): ?>
   <div class="bg-danger" style="margin-bottom:15px;padding:15px;border-radius:10px">
     <p>
       SquidTracks や splatnet2statink をご利用の方は、必ず最新版にアップデートを行ってください。<br>

--- a/views/site/index.php
+++ b/views/site/index.php
@@ -163,7 +163,11 @@ if ($blogEntries):
               Html::encode(
                 Yii::$app->formatter->asRelativeTime($t)
               ),
-              ['datetime' => $t->format(DateTime::ATOM)]
+              [
+                'datetime' => $t->format(DateTime::ATOM),
+                'title' => Yii::$app->formatter->asDateTime($t, 'medium'),
+                'class' => 'auto-tooltip',
+              ]
             ),
           ]),
           []


### PR DESCRIPTION
[Japanese Calendar (Japanese Era)](https://en.wikipedia.org/wiki/Japanese_era_name) Support.

Example:
Japanese (Gregorian):  `2019/04/18` (April 18th, 2019)
Japanese (JP Era): `H31/04/18` `平成31年4月18日`

Note:
Current ICU Library does not support [upcoming era "Reiwa" (令和)](https://en.wikipedia.org/wiki/Reiwa_period) yet.
So, maybe we'll see [平成](https://en.wikipedia.org/wiki/Heisei_period)31年5月1日 instead of 令和元年5月1日 or 令和1年5月1日.