### PR TITLE
Fix Japanese Calendar Behavior (fixes #462)

### DIFF
--- a/components/web/Application.php
+++ b/components/web/Application.php
@@ -5,14 +5,53 @@
  * @author AIZAWA Hina <hina@bouhime.com>
  */
 
+declare(strict_types=1);
+
 namespace app\components\web;
 
+use IntlDateFormatter;
 use Yii;
 use yii\web\Application as Base;
 
 class Application extends Base
 {
+    private $locale = null;
     private $region = 'jp';
+
+    public function setLocale(string $locale): self
+    {
+        $atPos = strpos($locale, '@');
+        $additional = ($atPos === false)
+            ? ''
+            : substr($locale, $atPos + 1);
+        $this->locale = $locale;
+        Yii::$app->language = substr($locale, 0, $atPos === false ? PHP_INT_MAX : $atPos);
+        Yii::$app->formatter->locale = rtrim(implode('@', [
+            str_replace('-', '_', Yii::$app->language),
+            $additional,
+        ]), '@');
+        Yii::$app->formatter->calendar = (strpos($additional, 'calendar=') !== false)
+            ? IntlDateFormatter::TRADITIONAL
+            : IntlDateFormatter::GREGORIAN;
+        
+        Yii::info('Language/Locale updated: ' . implode(', ', [
+            'app.language=' . Yii::$app->language,
+            'app.locale=' . $this->locale,
+            'fmt.locale=' . Yii::$app->formatter->locale,
+            'fmt.calendar=' . (
+                Yii::$app->formatter->calendar === IntlDateFormatter::TRADITIONAL
+                    ? 'TRADITIONAL'
+                    : 'GREGORIAN'
+            ),
+        ]), __METHOD__);
+
+        return $this;
+    }
+
+    public function getLocale(): string
+    {
+        return $this->locale ?: Yii::$app->language;
+    }
 
     public function setSplatoonRegion($region)
     {

--- a/components/web/Controller.php
+++ b/components/web/Controller.php
@@ -46,16 +46,7 @@ class Controller extends Base
 
         if ($lang) {
             Yii::$app->language = $lang->getLanguageId();
-            if ($lang->di) {
-                $di = is_string($lang->di) ? json_decode($lang->di, true) : $lang->di;
-                if (is_array($di)) {
-                    foreach ($di as $component => $data) {
-                        foreach ($data as $key => $value) {
-                            Yii::$app->$component->$key = $value;
-                        }
-                    }
-                }
-            }
+            Yii::$app->locale = $lang->lang;
         }
     }
 

--- a/components/widgets/LanguageDialog.php
+++ b/components/widgets/LanguageDialog.php
@@ -50,7 +50,7 @@ class LanguageDialog extends Dialog
     {
         return array_map(
             function (Language $lang): string {
-                if ($lang->lang === Yii::$app->language) {
+                if ($lang->lang === Yii::$app->locale) {
                     return Html::tag('div', $this->renderLanguageItem($lang), [
                         'class' => [
                             'list-group-item',

--- a/migrations/m190502_085334_remove_di_from_language.php
+++ b/migrations/m190502_085334_remove_di_from_language.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * @copyright Copyright (C) 2015-2019 AIZAWA Hina
+ * @license https://github.com/fetus-hina/stat.ink/blob/master/LICENSE MIT
+ * @author AIZAWA Hina <hina@bouhime.com>
+ */
+declare(strict_types=1);
+
+use app\components\db\Migration;
+
+class m190502_085334_remove_di_from_language extends Migration
+{
+    public function safeUp()
+    {
+        $this->execute('ALTER TABLE {{language}} DROP COLUMN [[di]]');
+    }
+
+    public function safeDown()
+    {
+        $this->execute('ALTER TABLE {{language}} ADD COLUMN [[di]] JSONB NULL');
+    }
+}

--- a/models/Language.php
+++ b/models/Language.php
@@ -21,7 +21,6 @@ use yii\db\ActiveRecord;
  * @property string $name
  * @property string $name_en
  * @property integer $support_level_id
- * @property array $di
  *
  * @property SupportLevel $supportLevel
  * @property LanguageCharset[] $languageCharsets
@@ -54,7 +53,6 @@ class Language extends ActiveRecord
             [['lang', 'name', 'name_en', 'support_level_id'], 'required'],
             [['support_level_id'], 'default', 'value' => null],
             [['support_level_id'], 'integer'],
-            [['di'], 'safe'],
             [['lang', 'name', 'name_en'], 'string', 'max' => 32],
             [['lang'], 'unique'],
             [['name_en'], 'unique'],
@@ -74,7 +72,6 @@ class Language extends ActiveRecord
             'name' => 'Name',
             'name_en' => 'Name En',
             'support_level_id' => 'Support Level ID',
-            'di' => 'Di',
         ];
     }
 


### PR DESCRIPTION
- Fix #462 
- Remove `"language"."di"` column from database schema. Because it's very ugly and made `app\components\web\Application` smart.