### PR TITLE
Fix time zone configuration (closes #466)

### DIFF
--- a/components/web/Controller.php
+++ b/components/web/Controller.php
@@ -186,6 +186,7 @@ class Controller extends Base
         })();
         if ($tz) {
             Yii::$app->setTimeZone($tz->identifier);
+            Yii::$app->formatter->timeZone = $tz->identifier;
             Yii::$app->setSplatoonRegion($tz->region_id);
         }
     }


### PR DESCRIPTION
原因:
ユーザがタイムゾーン設定を `Etc/UTC` に設定しているとき、アプリケーションの設定 `Yii::$app->timeZone` は `Etc/UTC` になっているが、フォーマッタの設定 `Yii::$app->formatter->timeZone` は `Asia/Tokyo` になってしまっていた。

発生原因コミット:
b96850219c53d177ca9fa9e962ebe09a86f80ca8

前提知識:

  - `Yii::$app->timeZone` の初期設定は `Asia/Tokyo`
    https://github.com/fetus-hina/stat.ink/blob/37bd3ed17a78d9667e4dd82e31ff2472c3fa2a6d/config/web.php#L15

  - `Yii::$app->formatter->timeZone` の初期設定は `null` （未設定）

  - `yii\i18n\Formatter::$timeZone` は未設定なら Formatter の初期化時に、 `Yii::$app->timeZone` からコピーされる
    https://github.com/yiisoft/yii2/blob/6d10d1f05df9c85ea0ca127bdc6bdc900bc9c6ba/framework/i18n/Formatter.php#L382-L384

発生順序:

  1. アプリケーション設定により、 `Yii::$app->timeZone` が `Asia/Tokyo` に初期化される

  2. アプリケーション初期化処理中に、設定言語の処理が行われる。
     https://github.com/fetus-hina/stat.ink/blob/37bd3ed17a78d9667e4dd82e31ff2472c3fa2a6d/components/web/Controller.php#L29-L51

  3. コミット b96850219c53d177ca9fa9e962ebe09a86f80ca8 の追加により、`Yii::$app->locale` にロケール設定（例：`ja-JP@calendar=japanese`）が行われる

  4. `app\components\web\Application::setLocale()` 内で、`Yii::$app->formatter->locale` に対する設定（例：`ja_JP@calendar=japanese`）が行われる
     https://github.com/fetus-hina/stat.ink/blob/37bd3ed17a78d9667e4dd82e31ff2472c3fa2a6d/components/web/Application.php#L29-L32

  5. このタイミングで、`Yii::$app->formatter` の初期化が行われる（＝このタイミングで `Yii::$app->timeZone` がコピーされる）。この時点ではまだタイムゾーン設定の読み込みは行われていないので、ここでコピーされる値は必ず `Asia/Tokyo`。

  6. `app\components\web\Controller` でタイムゾーンの設定の反映が行われ、 `Yii::$app->timeZone` が正しく設定される。ここで、すでにコピーされてしまった `Yii::$app->formatter` のタイムゾーン設定は `Asia/Tokyo` のまま。

  7. 実際のフォーマットは `Yii::$app->formatter->timeZone` の設定に従うので、常に `Asia/Tokyo` でフォーマットされる。

前述のコミット以前は、そのタイミングでのフォーマッタの初期化はなかったので、タイムゾーンが設定されたあとにフォーマッタにコピーされていて動いた。