### PR TITLE
Switch to Discord.com for webhooks

### DIFF
--- a/models/SlackAddForm.php
+++ b/models/SlackAddForm.php
@@ -91,7 +91,7 @@ class SlackAddForm extends Model
 
             // Discord
             sprintf('/^%s/ui', implode('', [
-                $quote('https://discordapp.com/api/webhooks/'),
+                $quote('https://discord.com/api/webhooks/'),
                 '\d+', // snowflake
                 $quote('/'),
                 '[0-9A-Za-z_-]+',


### PR DESCRIPTION
A few months ago Discord switched from using discordapp.com to simply discord.com. This pull request fixes the validation issue. 

In the future this probably shouldn't even have validation so people can build their own web hooks. 