### PR TITLE
add 2 columns to csv export functions

### DIFF
--- a/actions/user/Download2Action.php
+++ b/actions/user/Download2Action.php
@@ -69,7 +69,7 @@ class Download2Action extends BaseAction
         $resp = Yii::$app->response;
         $resp->setDownloadHeaders(
             'statink-ikalog-2.csv',
-            'text/cvs; charset=' . $charset[1],
+            'text/csv; charset=' . $charset[1],
             false,
             null
         );
@@ -93,7 +93,7 @@ class Download2Action extends BaseAction
     private function runCsv()
     {
         $resp = Yii::$app->response;
-        $resp->setDownloadHeaders('statink-2.csv', 'text/cvs; charset=UTF-8', false, null);
+        $resp->setDownloadHeaders('statink-2.csv', 'text/csv; charset=UTF-8', false, null);
         $resp->format = 'csv';
         $battles = $this->user->getBattle2s()
             ->with(['lobby', 'mode', 'rule', 'map', 'weapon', 'rank', 'rankAfter'])
@@ -111,6 +111,8 @@ class Download2Action extends BaseAction
                 Yii::t('app', 'Team ID'),
                 Yii::t('app', 'Rank'),
                 Yii::t('app', 'Rank (After)'),
+                Yii::t('app', 'X Power'),
+                Yii::t('app', 'X Power (after)'),
                 Yii::t('app', 'Power Level'),
                 Yii::t('app', 'League Power'),
                 Yii::t('app', 'Level'),

--- a/actions/user/Download2Action.php
+++ b/actions/user/Download2Action.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) 2015-2017 AIZAWA Hina
  * @license https://github.com/fetus-hina/stat.ink/blob/master/LICENSE MIT
  * @author AIZAWA Hina <hina@fetus.jp>
+ * @author li <nvblstr@gmail.com>
  */
 
 namespace app\actions\user;
@@ -111,8 +112,6 @@ class Download2Action extends BaseAction
                 Yii::t('app', 'Team ID'),
                 Yii::t('app', 'Rank'),
                 Yii::t('app', 'Rank (After)'),
-                Yii::t('app', 'X Power'),
-                Yii::t('app', 'X Power (after)'),
                 Yii::t('app', 'Power Level'),
                 Yii::t('app', 'League Power'),
                 Yii::t('app', 'Level'),
@@ -121,6 +120,8 @@ class Download2Action extends BaseAction
                 Yii::t('app', 'k+a'),
                 Yii::t('app', 'Specials'),
                 Yii::t('app', 'Inked'),
+                Yii::t('app', 'X Power'),
+                Yii::t('app', 'X Power (after)'),
             ];
             foreach ($battles->each() as $battle) {
                 yield $battle->toCsvArray();

--- a/models/Battle2.php
+++ b/models/Battle2.php
@@ -1674,6 +1674,8 @@ class Battle2 extends ActiveRecord
                     $this->rank_after_exp !== null ? $this->rank_after_exp : ''
                 ))
                 : '',
+            $this->x_power,
+            $this->x_power_after,
             $this->estimate_gachi_power,
             $this->league_point,
             $this->level,

--- a/models/Battle2.php
+++ b/models/Battle2.php
@@ -5,6 +5,7 @@
  * @license https://github.com/fetus-hina/stat.ink/blob/master/LICENSE MIT
  * @author AIZAWA Hina <hina@fetus.jp>
  * @author Yoshiyuki Kawashima <ykawashi7@gmail.com>
+ * @author li <nvblstr@gmail.com>
  */
 
 namespace app\models;
@@ -1674,8 +1675,6 @@ class Battle2 extends ActiveRecord
                     $this->rank_after_exp !== null ? $this->rank_after_exp : ''
                 ))
                 : '',
-            $this->x_power,
-            $this->x_power_after,
             $this->estimate_gachi_power,
             $this->league_point,
             $this->level,
@@ -1684,6 +1683,8 @@ class Battle2 extends ActiveRecord
             $this->kill_or_assist,
             $this->special,
             $this->inked,
+            $this->x_power,
+            $this->x_power_after,
         ];
     }
 


### PR DESCRIPTION
現状エクスポートしたCSVファイルにバトルごとのXパワーが出力されず履歴が確認できないため、出力処理に列を追加しました。
併せて誤字があったため修正しました。
Now X players can't check the history of X Power in exported CSV file.
So I added 'X Power' and 'X Power (after)' columns in 'runCsv' and 'toCsvArray' functions.
And I fixed typo 'cvs' -> 'csv'.