### PR TITLE
Allow 5-digit splashtag #s

### DIFF
--- a/models/api/v3/postBattle/PlayerForm.php
+++ b/models/api/v3/postBattle/PlayerForm.php
@@ -55,7 +55,7 @@ final class PlayerForm extends Model
             [['me', 'disconnected'], 'in', 'range' => ['yes', 'no', true, false]],
             [['rank_in_team'], 'integer', 'min' => 1, 'max' => 4],
             [['name'], 'string', 'min' => 1, 'max' => 10],
-            [['number'], 'integer', 'min' => 0, 'max' => 9999],
+            [['number'], 'integer', 'min' => 0, 'max' => 99999],
             [['splashtag_title'], 'string', 'max' => 255],
             [['weapon'], 'string'],
             [['weapon'], KeyValidator::class,


### PR DESCRIPTION
Allow `number` to go up to `99999` insteas of `9999`. There are a couple occurrences of this in my battle JSONs:

![image](https://user-images.githubusercontent.com/7245874/192104528-e85410e4-88b5-4b2f-a0b8-95fa896e48d3.png)
![image](https://user-images.githubusercontent.com/7245874/192104534-18db04e7-67c2-4863-96d9-261f60fbeeb3.png)
![image](https://user-images.githubusercontent.com/7245874/192104538-a926089b-fb1f-4a8a-9c10-c20b072f3b7d.png)

Maybe a bug by Nintendo, but if we don't allow it, the battles can't be uploaded.