### PR TITLE
fr translation fix

### DIFF
--- a/messages/fr/app.php
+++ b/messages/fr/app.php
@@ -157,7 +157,7 @@ return [
     'D/min' => 'm/min',
     'Daily Report' => 'Rapport journalier',
     'Data Sent' => 'Données envoyées',
-    'Date Time' => 'Heure/Jour d\'envoi',
+    'Date Time' => 'Date et heure',
     'Dead' => 'Mort',
     'Deaths' => 'Morts',
     'Deaths (average):' => 'Morts (moyenne)',


### PR DESCRIPTION
"Heure/Jour d'envoi" means "Date/time of sending", whereas this string refers to the date/time that the game took place as reported by the uploader.