### PR TITLE
Splatoon 3 v10.0.0

### DIFF
--- a/migrations/m250611_182733_s3_v10_0_0.php
+++ b/migrations/m250611_182733_s3_v10_0_0.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * @copyright Copyright (C) 2015-2025 AIZAWA Hina
+ * @license https://github.com/fetus-hina/stat.ink/blob/master/LICENSE MIT
+ * @author AIZAWA Hina <hina@fetus.jp>
+ */
+
+declare(strict_types=1);
+
+use app\components\db\Migration;
+use app\components\db\VersionMigration;
+
+final class m250611_182733_s3_v10_0_0 extends Migration
+{
+    use VersionMigration;
+
+    /**
+     * @inheritdoc
+     */
+    #[Override]
+    public function safeUp()
+    {
+        $this->upVersion3(
+            '10.0',
+            'v10.0.x',
+            '10.0.0',
+            'v10.0.0',
+            new DateTimeImmutable('2025-06-12T10:10:00+09:00'),
+        );
+
+        return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    #[Override]
+    public function safeDown()
+    {
+        $this->downVersion3('10.0.0', '9.3.0');
+
+        return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function vacuumTables(): array
+    {
+        return [
+            '{{%splatoon_version3}}',
+            '{{%splatoon_version_group3}}',
+        ];
+    }
+}


### PR DESCRIPTION
fix #1547 

This pull request introduces a new migration file to update the Splatoon versioning system to version 10.0.0. The migration includes methods for safely applying and reverting the changes, as well as specifying the tables that require vacuuming.

Migration for version update:

* [`migrations/m250611_182733_s3_v10_0_0.php`](diffhunk://#diff-33f7eb0c2bca707ff2e1c87ac064b2ad96fa4dc93d2158e4354b6f0400b91de9R1-R56): Added a migration file to update the Splatoon versioning system to version 10.0.0. The `safeUp` method applies the version update, while the `safeDown` method reverts it. The `vacuumTables` method specifies the tables to vacuum (`{{%splatoon_version3}}` and `{{%splatoon_version_group3}}`).