### PR TITLE
Add Series Weapon Power display and icon alt-text support

### DIFF
--- a/components/widgets/Icon.php
+++ b/components/widgets/Icon.php
@@ -541,6 +541,7 @@ final class Icon
     public static function s3Weapon(
         Weapon3|SalmonWeapon3|string|null $weapon,
         ?string $size = null,
+        ?string $alt = null,
     ): ?string {
         $key = match (true) {
             $weapon instanceof Weapon3, $weapon instanceof SalmonWeapon3 => $weapon->key,
@@ -783,7 +784,7 @@ final class Icon
         return self::assetImage(
             WeaponIconAsset::class,
             "{$directory}/{$key}.png",
-            Yii::t('app-weapon3', (string)$weapon?->name),
+            $alt ?? Yii::t('app-weapon3', (string)$weapon?->name),
             true,
             $size,
         );

--- a/views/show-v3/user/list-options/columns/fest-power.php
+++ b/views/show-v3/user/list-options/columns/fest-power.php
@@ -14,7 +14,7 @@ use app\models\Battle3;
 $f = Yii::$app->formatter;
 
 return [
-  'contentOptions' => ['class' => 'cell-fest-power text-right'],
+  'contentOptions' => ['class' => 'cell-fest-power text-right nobr'],
   'format' => 'raw',
   'headerOptions' => ['class' => 'cell-fest-power'],
   'label' => Yii::t('app', 'Power'),
@@ -30,6 +30,14 @@ return [
     $model->bankara_power_after !== null && $model->bankara_power_after >= 0.1 => vsprintf('%s %s', [
       Icon::s3LobbyBankara(),
       $f->asDecimal((float)$model->bankara_power_after, 1),
+    ]),
+    $model->series_weapon_power_before !== null && $model->series_weapon_power_before >= 0.1 => vsprintf('%s %s', [
+      Icon::s3Weapon($model?->weapon, alt: Yii::t('app', 'Series Weapon Power')),
+      $f->asDecimal((float)$model->series_weapon_power_before, 1),
+    ]),
+    $model->series_weapon_power_after !== null && $model->series_weapon_power_after >= 0.1 => vsprintf('%s %s', [
+      Icon::s3Weapon($model?->weapon, alt: Yii::t('app', 'Series Weapon Power')),
+      $f->asDecimal((float)$model->series_weapon_power_after, 1),
     ]),
     $model->x_power_before !== null && $model->x_power_before >= 0.1 => vsprintf('%s %s', [
       Icon::s3LobbyX(),


### PR DESCRIPTION
* Introduce optional `$alt` parameter to `Icon::s3Weapon()` for customizable alternative text
* Show Series Weapon Power (before / after) with weapon icon in the user list’s fest-power column
* Format Series Weapon Power values to one decimal place
* Add `nobr` class to the fest-power cell to prevent line breaks

Closes #1569