### PR TITLE
Add Series Weapon Power history chart and supporting DB index

### DIFF
--- a/migrations/m250627_210058_battle3_series_weapon_power_history.php
+++ b/migrations/m250627_210058_battle3_series_weapon_power_history.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * @copyright Copyright (C) 2015-2025 AIZAWA Hina
+ * @license https://github.com/fetus-hina/stat.ink/blob/master/LICENSE MIT
+ * @author AIZAWA Hina <hina@fetus.jp>
+ */
+
+declare(strict_types=1);
+
+use app\components\db\Migration;
+
+final class m250627_210058_battle3_series_weapon_power_history extends Migration
+{
+    /**
+     * @inheritdoc
+     */
+    #[Override]
+    public function safeUp()
+    {
+        $db = $this->getDb();
+        $this->execute(
+            vsprintf('CREATE UNIQUE INDEX %s ON %s (%s) WHERE (%s)', [
+                $db->quoteTableName('{{%battle3_series_weapon_power_history}}'),
+                $db->quoteTableName('{{%battle3}}'),
+                implode(', ', [
+                    $db->quoteColumnName('user_id'),
+                    $db->quoteColumnName('weapon_id'),
+                    $db->quoteColumnName('end_at') . ' DESC',
+                    $db->quoteColumnName('id') . ' DESC',
+                ]),
+                implode(') AND (', [
+                    '[[is_deleted]] = FALSE',
+                    '[[end_at]] IS NOT NULL',
+                    'COALESCE([[series_weapon_power_after]], [[series_weapon_power_before]]) IS NOT NULL',
+                    vsprintf('%s >= %s::timestamptz', [
+                        $db->quoteColumnName('end_at'),
+                        $db->quoteValue('2025-06-12T01:00:00+00:00'),
+                    ]),
+                    vsprintf('%s = %d', [
+                        $db->quoteColumnName('lobby_id'),
+                        $this->key2id('{{%lobby3}}', 'bankara_challenge'),
+                    ]),
+                ]),
+            ]),
+        );
+
+        return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    #[Override]
+    public function safeDown()
+    {
+        $this->dropIndex('{{%battle3}}', '{{%battle3_series_weapon_power_history}}');
+
+        return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    #[Override]
+    protected function vacuumTables(): array
+    {
+        return [
+            '{{%battle3}}',
+        ];
+    }
+}

--- a/views/show-v3/battle/details.php
+++ b/views/show-v3/battle/details.php
@@ -64,6 +64,7 @@ echo DetailView::widget([
     require __DIR__ . '/details/x-power-chart.php',
     require __DIR__ . '/details/bankara-power.php',
     require __DIR__ . '/details/series-weapon-power.php',
+    require __DIR__ . '/details/series-weapon-power-chart.php',
     require __DIR__ . '/details/clout.php',
     require __DIR__ . '/details/fest-power.php',
     require __DIR__ . '/details/event-power.php',

--- a/views/show-v3/battle/details/series-weapon-power-chart.php
+++ b/views/show-v3/battle/details/series-weapon-power-chart.php
@@ -1,0 +1,163 @@
+<?php
+
+/**
+ * @copyright Copyright (C) 2023-2025 AIZAWA Hina
+ * @license https://github.com/fetus-hina/stat.ink/blob/master/LICENSE MIT
+ * @author AIZAWA Hina <hina@fetus.jp>
+ */
+
+declare(strict_types=1);
+
+use app\assets\ChartJsAsset;
+use app\assets\ColorSchemeAsset;
+use app\assets\JqueryEasyChartjsAsset;
+use app\assets\RatioAsset;
+use app\components\helpers\TypeHelper;
+use app\models\Battle3;
+use app\models\Season3;
+use yii\db\Expression as DbExpr;
+use yii\helpers\ArrayHelper;
+use yii\helpers\Html;
+use yii\helpers\Json;
+use yii\web\JsExpression;
+use yii\web\View;
+
+/**
+ * @var View $this
+ */
+
+return [
+  'label' => Yii::t('app', 'Series Weapon Power'),
+  'format' => 'raw',
+  'value' => function (Battle3 $model): ?string {
+    if ($model->series_weapon_power_before === null && $model->series_weapon_power_after === null) {
+      return null;
+    }
+
+    if ($model->weapon_id === null) {
+      return null;
+    }
+
+    $lobby = $model->lobby;
+    if ($lobby?->key !== 'bankara_challenge') {
+      return null;
+    }
+
+    $powerList = ArrayHelper::getColumn(
+      Battle3::find()
+        ->andWhere(['and',
+          [
+            '{{%battle3}}.[[is_deleted]]' => false,
+            '{{%battle3}}.[[lobby_id]]' => $lobby->id,
+            '{{%battle3}}.[[user_id]]' => $model->user_id,
+            '{{%battle3}}.[[weapon_id]]' => $model->weapon_id,
+          ],
+          ['not', ['{{%battle3}}.[[end_at]]' => null]],
+          ['<=', '{{%battle3}}.[[end_at]]', $model->end_at],
+          ['>=', '{{%battle3}}.[[end_at]]', '2025-06-12T01:00:00+00:00'],
+          'COALESCE({{%battle3}}.[[series_weapon_power_after]], {{%battle3}}.[[series_weapon_power_before]]) IS NOT NULL',
+        ])
+        ->orderBy([
+          '{{%battle3}}.[[end_at]]' => SORT_DESC,
+          '{{%battle3}}.[[id]]' => SORT_DESC,
+        ])
+        ->limit(500)
+        ->select([
+          'series_weapon_power' => 'COALESCE({{%battle3}}.[[series_weapon_power_after]], {{%battle3}}.[[series_weapon_power_before]])',
+        ])
+        ->asArray()
+        ->all(),
+      fn (array $v): ?float => TypeHelper::floatOrNull($v['series_weapon_power'] ?? null),
+    );
+    if (count($powerList) < 2) {
+      return null;
+    }
+
+    // 古い順に並べかえる
+    $powerList = array_values(array_reverse($powerList));
+
+    $id = 'series-power-chart';
+
+    ChartJsAsset::register($this);
+    ColorSchemeAsset::register($this);
+    JqueryEasyChartjsAsset::register($this);
+    RatioAsset::register($this);
+
+    $configJson = Json::encode([
+      'data' => [
+        'labels' => [
+          Yii::t('app', 'Series Weapon Power'),
+        ],
+        'datasets' => [
+          [
+            'backgroundColor' => [ new JsExpression('window.colorScheme.graph1') ],
+            'borderColor' => [ new JsExpression('window.colorScheme.graph1') ],
+            'borderWidth' => 2,
+            'fill' => false,
+            'label' => Yii::t('app', 'X Power'),
+            'pointRadius' => 0,
+            'type' => 'line',
+            'data' => array_map(
+              fn (int $x, ?float $y) => compact('x', 'y'),
+              range(-1 * count($powerList) + 1, 0),
+              $powerList,
+            ),
+          ],
+        ],
+      ],
+      'options' => [
+        'animation' => [
+          'duration' => 0,
+        ],
+        'aspectRatio' => 16 / 9,
+        'plugins' => [
+          'legend' => [
+            'display' => false,
+          ],
+          'tooltip' => [
+            'enabled' => false,
+          ],
+        ],
+        'scales' => [
+          'x' => [
+            'grid' => [
+              'offset' => false,
+            ],
+            'max' => 0,
+            'offset' => true,
+            'title' => [
+              'display' => false,
+            ],
+            'type' => 'linear',
+          ],
+          'y' => [
+            'title' => [
+              'display' => false,
+            ],
+            'type' => 'linear',
+          ],
+        ],
+      ],
+    ]);
+
+    $this->registerJs("$('#{$id}').easyChartJs();");
+
+    return Html::tag(
+      'div',
+      implode('', [
+        Html::tag(
+          'div',
+          '',
+          [
+            'class' => 'mb-2 p-0 w-100 ratio ratio-16x9',
+            'id' => $id,
+            'data' => [
+              'chart' => $configJson,
+            ],
+          ],
+        ),
+      ]),
+      ['style' => ['max-width' => '400px']],
+    );
+  },
+];

--- a/views/show-v3/battle/details/series-weapon-power-chart.php
+++ b/views/show-v3/battle/details/series-weapon-power-chart.php
@@ -94,7 +94,7 @@ return [
             'borderColor' => [ new JsExpression('window.colorScheme.graph1') ],
             'borderWidth' => 2,
             'fill' => false,
-            'label' => Yii::t('app', 'X Power'),
+            'label' => Yii::t('app', 'Series Weapon Power'),
             'pointRadius' => 0,
             'type' => 'line',
             'data' => array_map(


### PR DESCRIPTION
Closes #1570 
---

This pull request introduces a new feature to track and display "Series Weapon Power" in the application. The most significant changes include the creation of a database migration for indexing relevant data, the addition of a new view component to render a chart, and the integration of this chart into the battle details page.

### Database Changes:
* Added a migration file `m250627_210058_battle3_series_weapon_power_history.php` to create a unique index for tracking "Series Weapon Power" in the `battle3` table. This index filters data based on conditions such as non-deleted battles, specific lobby type, and a minimum timestamp.

### Frontend Changes:
* Updated `views/show-v3/battle/details.php` to include the new `series-weapon-power-chart.php` component for rendering the "Series Weapon Power" chart.
* Created a new file `views/show-v3/battle/details/series-weapon-power-chart.php` to define the logic and rendering of the "Series Weapon Power" chart using Chart.js. This includes fetching and processing battle data, configuring the chart, and rendering it within a responsive container.