### PR TITLE
fix: Proper recent battle filtering

### DIFF
--- a/components/helpers/CombinedBattles.php
+++ b/components/helpers/CombinedBattles.php
@@ -116,6 +116,10 @@ final class CombinedBattles
      */
     private static function getCreatedAt(?Model $model): ?int
     {
+        if (isset($model->end_at)) {
+            return self::prepareTimestamp($model->end_at);
+        }
+
         if (
             method_exists($model, 'getCreatedAt') &&
             is_callable([$model, 'getCreatedAt'])


### PR DESCRIPTION
Fixed a bug in `CombinedBattles.php` where the timestamp they were ordered by was the uploaded time, not the match end time, causing potentially older matches to appear in front of newer ones if they were uploaded after.