### PR TITLE
fix: Accurate anarchy battle power

### DIFF
--- a/views/show-v3/user/list-options/columns/fest-power.php
+++ b/views/show-v3/user/list-options/columns/fest-power.php
@@ -23,13 +23,13 @@ return [
       Icon::s3LobbySplatfest(),
       $f->asDecimal((float)$model->fest_power, 1),
     ]),
-    $model->bankara_power_before !== null && $model->bankara_power_before >= 0.1 => vsprintf('%s %s', [
-      Icon::s3LobbyBankara(),
-      $f->asDecimal((float)$model->bankara_power_before, 1),
-    ]),
     $model->bankara_power_after !== null && $model->bankara_power_after >= 0.1 => vsprintf('%s %s', [
       Icon::s3LobbyBankara(),
       $f->asDecimal((float)$model->bankara_power_after, 1),
+    ]),
+    $model->bankara_power_before !== null && $model->bankara_power_before >= 0.1 => vsprintf('%s %s', [
+      Icon::s3LobbyBankara(),
+      $f->asDecimal((float)$model->bankara_power_before, 1),
     ]),
     $model->series_weapon_power_before !== null && $model->series_weapon_power_before >= 0.1 => vsprintf('%s %s', [
       Icon::s3Weapon($model?->weapon, alt: Yii::t('app', 'Series Weapon Power')),


### PR DESCRIPTION
Fixes #1347 - fixes the issue described there, where the `before` power is preferred over the `after` for some reason.