### PR TITLE
to fix #1665, ignore Series Weapon Power < 0.1

### DIFF
--- a/views/show-v3/battle/details/series-weapon-power-chart.php
+++ b/views/show-v3/battle/details/series-weapon-power-chart.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) 2023-2025 AIZAWA Hina
+ * @copyright Copyright (C) 2023-2026 AIZAWA Hina
  * @license https://github.com/fetus-hina/stat.ink/blob/master/LICENSE MIT
  * @author AIZAWA Hina <hina@fetus.jp>
  */
@@ -98,7 +98,19 @@ return [
             'pointRadius' => 0,
             'type' => 'line',
             'data' => array_map(
-              fn (int $x, ?float $y) => compact('x', 'y'),
+              fn (int $x, ?float $y) => [
+                'x' => $x,
+                // For visibility, values smaller than 0.1 are considered invalid.
+                // The Series Power can theoretically take values of 0.0 or negative values.
+                // Taking 0.0 is about as likely as obtaining a value around 4000.
+                // It's hard to imagine such people continuing to play until they get 0.0,
+                // and the probability that they are stat.ink users is even lower.
+                // If someone like that appears, it will be necessary to devise a method such as
+                // determining the threshold based on surrounding values.
+                //
+                // https://github.com/fetus-hina/stat.ink/issues/1665
+                'y' => (float)$y < 0.1 ? null : (float)$y,
+              ],
               range(-1 * count($powerList) + 1, 0),
               $powerList,
             ),


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- シリーズ武器パワーが0.1未満の場合は無効値として扱うように修正

- チャート表示の可読性向上のため、極端に低い数値を除外

- コメントにより修正の背景と意図を明確化

- 著作権表記の年次更新（2025→2026）


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["シリーズ武器パワー取得"] -- "0.1未満をnullに変換" --> B["チャート描画"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>series-weapon-power-chart.php</strong><dd><code>チャートデータのフィルタリングとコメント追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

views/show-v3/battle/details/series-weapon-power-chart.php

<ul><li>シリーズ武器パワーが0.1未満の場合にnullとして扱う処理を追加<br> <li> 表示上の問題に対応するためのコメントを詳細に記述<br> <li> 著作権表示の年次更新（2025年対応）<br> <li> GitHub issue #1665への参照をコメントに追加</ul>


</details>


  </td>
  <td><a href="https://github.com/fetus-hina/stat.ink/pull/1666/files#diff-bde374eb49461d3f633c09e89130011d96ae0fdd2a95409101aa1a9a9fb00ed7">+14/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

