### PR TITLE
Show passkey authenticator icons on the user passkey list

### DIFF
--- a/actions/user/PasskeyAction.php
+++ b/actions/user/PasskeyAction.php
@@ -12,6 +12,8 @@ namespace app\actions\user;
 
 use Yii;
 use app\models\UserPasskey;
+use yii\db\Query;
+use yii\helpers\ArrayHelper;
 use yii\web\ViewAction as BaseAction;
 
 use const SORT_ASC;
@@ -30,6 +32,39 @@ final class PasskeyAction extends BaseAction
         return $this->controller->render('passkey', [
             'user' => $ident,
             'passkeys' => $passkeys,
+            'aaguidInfo' => $this->buildAaguidInfo($passkeys),
         ]);
+    }
+
+    /**
+     * @param UserPasskey[] $passkeys
+     * @return array<string, array{name: string, mime_type: ?string, base64_data: ?string}>
+     */
+    private function buildAaguidInfo(array $passkeys): array
+    {
+        $aaguids = ArrayHelper::getColumn($passkeys, 'aaguid');
+        if (!$aaguids) {
+            return [];
+        }
+
+        $theme = Yii::$app->theme->isDarkTheme ? 'dark' : 'light';
+
+        $rows = (new Query())
+            ->select([
+                'aaguid' => '{{pa}}.[[aaguid]]',
+                'name' => '{{pa}}.[[name]]',
+                'mime_type' => '{{pai}}.[[mime_type]]',
+                'base64_data' => "REPLACE(ENCODE({{pai}}.[[data]], 'base64'), E'\\n', '')",
+            ])
+            ->from(['pa' => '{{%passkey_aaguid}}'])
+            ->leftJoin(
+                ['pai' => '{{%passkey_aaguid_icon}}'],
+                '{{pa}}.[[aaguid]] = {{pai}}.[[aaguid]] AND {{pai}}.[[theme]] = :theme',
+                [':theme' => $theme],
+            )
+            ->andWhere(['{{pa}}.[[aaguid]]' => $aaguids])
+            ->all();
+
+        return ArrayHelper::index($rows, 'aaguid');
     }
 }

--- a/commands/PasskeyAaguidController.php
+++ b/commands/PasskeyAaguidController.php
@@ -1,0 +1,186 @@
+<?php
+
+/**
+ * @copyright Copyright (C) 2015-2026 AIZAWA Hina
+ * @license https://github.com/fetus-hina/stat.ink/blob/master/LICENSE MIT
+ * @author AIZAWA Hina <hina@fetus.jp>
+ */
+
+declare(strict_types=1);
+
+namespace app\commands;
+
+use Throwable;
+use Yii;
+use app\components\helpers\DataUri;
+use app\components\helpers\db\Now;
+use yii\console\Controller;
+use yii\console\ExitCode;
+use yii\db\Connection;
+use yii\helpers\Json;
+use yii\httpclient\Client as HttpClient;
+use yii\httpclient\CurlTransport;
+
+use function assert;
+use function bin2hex;
+use function count;
+use function fprintf;
+use function fwrite;
+use function is_array;
+use function is_string;
+use function preg_match;
+use function sprintf;
+use function vfprintf;
+
+use const STDERR;
+
+final class PasskeyAaguidController extends Controller
+{
+    private const SOURCE_URL =
+        'https://raw.githubusercontent.com/passkeydeveloper/passkey-authenticator-aaguids/refs/heads/main/combined_aaguid.json';
+
+    private const AAGUID_REGEX = '/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i';
+
+    public $defaultAction = 'update';
+
+    public function actionUpdate(): int
+    {
+        $entries = $this->fetchEntries();
+        if ($entries === null) {
+            return ExitCode::UNSPECIFIED_ERROR;
+        }
+
+        if (count($entries) === 0) {
+            fwrite(STDERR, "Source JSON has no entries; skipping update.\n");
+            return ExitCode::OK;
+        }
+
+        $db = Yii::$app->db;
+        assert($db instanceof Connection);
+
+        $now = new Now();
+
+        $db->transaction(function (Connection $db) use ($entries, $now): void {
+            foreach ($entries as $aaguid => $info) {
+                $this->processEntry($db, (string)$aaguid, $info, $now);
+            }
+        });
+
+        return ExitCode::OK;
+    }
+
+    private function fetchEntries(): ?array
+    {
+        try {
+            vfprintf(STDERR, "Downloading %s\n", [self::SOURCE_URL]);
+
+            $client = Yii::createObject([
+                'class' => HttpClient::class,
+                'transport' => CurlTransport::class,
+            ]);
+            $response = $client->createRequest()
+                ->setOptions([
+                    'timeout' => 30,
+                    'userAgent' => sprintf(
+                        'stat.ink/%s (+https://github.com/fetus-hina/stat.ink)',
+                        Yii::$app->version,
+                    ),
+                    'maxRedirects' => 5,
+                ])
+                ->setMethod('get')
+                ->setUrl(self::SOURCE_URL)
+                ->send();
+            if (!$response->isOk) {
+                fprintf(STDERR, "Fetch failed, HTTP %d\n", $response->statusCode);
+                return null;
+            }
+
+            $decoded = Json::decode($response->content, true);
+            return is_array($decoded) ? $decoded : null;
+        } catch (Throwable $e) {
+            fprintf(STDERR, "Error: %s\n", $e->getMessage());
+            return null;
+        }
+    }
+
+    private function processEntry(Connection $db, string $aaguid, mixed $info, Now $now): void
+    {
+        if (preg_match(self::AAGUID_REGEX, $aaguid) !== 1) {
+            fwrite(STDERR, "Skipping invalid AAGUID: {$aaguid}\n");
+            return;
+        }
+
+        if (!is_array($info)) {
+            return;
+        }
+
+        $name = isset($info['name']) && is_string($info['name']) && $info['name'] !== ''
+            ? $info['name']
+            : null;
+        if ($name === null) {
+            return;
+        }
+
+        $this->upsertName($db, $aaguid, $name, $now);
+
+        foreach (['light', 'dark'] as $theme) {
+            $value = $info["icon_{$theme}"] ?? null;
+            if (!is_string($value) || $value === '') {
+                continue;
+            }
+
+            $parsed = DataUri::parse($value);
+            if ($parsed === null) {
+                fwrite(STDERR, "Skipping invalid icon_{$theme} for {$aaguid}\n");
+                continue;
+            }
+
+            [$mimeType, $binary] = $parsed;
+            $this->upsertIcon($db, $aaguid, $theme, $mimeType, $binary, $now);
+        }
+    }
+
+    private function upsertName(Connection $db, string $aaguid, string $name, Now $now): void
+    {
+        $sql =
+            'INSERT INTO {{%passkey_aaguid}} ' .
+            '([[aaguid]], [[name]], [[created_at]], [[updated_at]]) ' .
+            "VALUES (:aaguid, :name, {$now}, {$now}) " .
+            'ON CONFLICT ([[aaguid]]) DO UPDATE SET ' .
+            '[[name]] = {{excluded}}.[[name]], ' .
+            '[[updated_at]] = {{excluded}}.[[updated_at]] ' .
+            'WHERE {{%passkey_aaguid}}.[[name]] IS DISTINCT FROM {{excluded}}.[[name]]';
+
+        $db->createCommand($sql, [
+            ':aaguid' => $aaguid,
+            ':name' => $name,
+        ])->execute();
+    }
+
+    private function upsertIcon(
+        Connection $db,
+        string $aaguid,
+        string $theme,
+        string $mimeType,
+        string $binary,
+        Now $now,
+    ): void {
+        $sql =
+            'INSERT INTO {{%passkey_aaguid_icon}} ' .
+            '([[aaguid]], [[theme]], [[mime_type]], [[data]], [[created_at]], [[updated_at]]) ' .
+            "VALUES (:aaguid, :theme, :mime, decode(:data_hex, 'hex'), {$now}, {$now}) " .
+            'ON CONFLICT ([[aaguid]], [[theme]]) DO UPDATE SET ' .
+            '[[mime_type]] = {{excluded}}.[[mime_type]], ' .
+            '[[data]] = {{excluded}}.[[data]], ' .
+            '[[updated_at]] = {{excluded}}.[[updated_at]] ' .
+            'WHERE {{%passkey_aaguid_icon}}.[[mime_type]] IS DISTINCT FROM {{excluded}}.[[mime_type]] ' .
+            'OR {{%passkey_aaguid_icon}}.[[data]] IS DISTINCT FROM {{excluded}}.[[data]]';
+
+        $db->createCommand($sql, [
+            ':aaguid' => $aaguid,
+            ':theme' => $theme,
+            ':mime' => $mimeType,
+            ':data_hex' => bin2hex($binary),
+        ])->execute();
+    }
+}

--- a/components/helpers/DataUri.php
+++ b/components/helpers/DataUri.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * @copyright Copyright (C) 2015-2026 AIZAWA Hina
+ * @license https://github.com/fetus-hina/stat.ink/blob/master/LICENSE MIT
+ * @author AIZAWA Hina <hina@fetus.jp>
+ */
+
+declare(strict_types=1);
+
+namespace app\components\helpers;
+
+use function base64_decode;
+use function preg_match;
+use function strtolower;
+
+final class DataUri
+{
+    /**
+     * Parses a base64-encoded `data:` URI into its MIME type and decoded binary.
+     *
+     * @return array{string, string}|null `[mime_type, binary]`, or `null` if the input is not a
+     *                                    well-formed base64-encoded data URI.
+     */
+    public static function parse(string $uri): ?array
+    {
+        if (preg_match('#^data:([a-z0-9.+/-]+);base64,([A-Za-z0-9+/=]*)$#i', $uri, $match) !== 1) {
+            return null;
+        }
+
+        $binary = base64_decode($match[2], true);
+        if ($binary === false) {
+            return null;
+        }
+
+        return [strtolower($match[1]), $binary];
+    }
+}

--- a/migrations/m260503_170504_passkey_aaguid.php
+++ b/migrations/m260503_170504_passkey_aaguid.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * @copyright Copyright (C) 2015-2026 AIZAWA Hina
+ * @license https://github.com/fetus-hina/stat.ink/blob/master/LICENSE MIT
+ * @author AIZAWA Hina <hina@fetus.jp>
+ */
+
+declare(strict_types=1);
+
+use app\components\db\Migration;
+
+final class m260503_170504_passkey_aaguid extends Migration
+{
+    /**
+     * @inheritdoc
+     */
+    #[Override]
+    public function safeUp()
+    {
+        $this->createTable('{{%passkey_aaguid}}', [
+            'aaguid' => 'UUID NOT NULL',
+            'name' => $this->text()->notNull(),
+            'created_at' => $this->timestampTZ(0)->notNull(),
+            'updated_at' => $this->timestampTZ(0)->notNull(),
+
+            'PRIMARY KEY ([[aaguid]])',
+        ]);
+
+        $this->createTable('{{%passkey_aaguid_icon}}', [
+            'aaguid' =>
+                'UUID NOT NULL REFERENCES {{%passkey_aaguid}}([[aaguid]]) ON DELETE CASCADE',
+            'theme' => $this->string(8)->notNull()
+                ->append("CHECK ([[theme]] IN ('light', 'dark'))"),
+            'mime_type' => $this->string(32)->notNull(),
+            'data' => $this->binary()->notNull(),
+            'created_at' => $this->timestampTZ(0)->notNull(),
+            'updated_at' => $this->timestampTZ(0)->notNull(),
+
+            'PRIMARY KEY ([[aaguid]], [[theme]])',
+        ]);
+
+        return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    #[Override]
+    public function safeDown()
+    {
+        $this->dropTable('{{%passkey_aaguid_icon}}');
+        $this->dropTable('{{%passkey_aaguid}}');
+
+        return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    #[Override]
+    protected function vacuumTables(): array
+    {
+        return [
+            '{{%passkey_aaguid}}',
+            '{{%passkey_aaguid_icon}}',
+        ];
+    }
+}

--- a/models/PasskeyAaguid.php
+++ b/models/PasskeyAaguid.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * @copyright Copyright (C) 2026 AIZAWA Hina
+ * @license https://github.com/fetus-hina/stat.ink/blob/master/LICENSE MIT
+ * @author AIZAWA Hina <hina@fetus.jp>
+ */
+
+declare(strict_types=1);
+
+namespace app\models;
+
+use Override;
+use yii\db\ActiveQuery;
+use yii\db\ActiveRecord;
+
+/**
+ * This is the model class for table "passkey_aaguid".
+ *
+ * @property string $aaguid
+ * @property string $name
+ * @property string $created_at
+ * @property string $updated_at
+ *
+ * @property PasskeyAaguidIcon[] $passkeyAaguidIcons
+ */
+class PasskeyAaguid extends ActiveRecord
+{
+    public static function tableName()
+    {
+        return 'passkey_aaguid';
+    }
+
+    #[Override]
+    public function rules()
+    {
+        return [
+            [['aaguid', 'name', 'created_at', 'updated_at'], 'required'],
+            [['aaguid', 'name'], 'string'],
+            [['created_at', 'updated_at'], 'safe'],
+            [['aaguid'], 'unique'],
+        ];
+    }
+
+    #[Override]
+    public function attributeLabels()
+    {
+        return [
+            'aaguid' => 'Aaguid',
+            'name' => 'Name',
+            'created_at' => 'Created At',
+            'updated_at' => 'Updated At',
+        ];
+    }
+
+    public function getPasskeyAaguidIcons(): ActiveQuery
+    {
+        return $this->hasMany(PasskeyAaguidIcon::class, ['aaguid' => 'aaguid']);
+    }
+}

--- a/models/PasskeyAaguidIcon.php
+++ b/models/PasskeyAaguidIcon.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * @copyright Copyright (C) 2026 AIZAWA Hina
+ * @license https://github.com/fetus-hina/stat.ink/blob/master/LICENSE MIT
+ * @author AIZAWA Hina <hina@fetus.jp>
+ */
+
+declare(strict_types=1);
+
+namespace app\models;
+
+use Override;
+use yii\db\ActiveQuery;
+use yii\db\ActiveRecord;
+
+/**
+ * This is the model class for table "passkey_aaguid_icon".
+ *
+ * @property string $aaguid
+ * @property string $theme
+ * @property string $mime_type
+ * @property resource $data
+ * @property string $created_at
+ * @property string $updated_at
+ *
+ * @property PasskeyAaguid $aagu
+ */
+class PasskeyAaguidIcon extends ActiveRecord
+{
+    public static function tableName()
+    {
+        return 'passkey_aaguid_icon';
+    }
+
+    #[Override]
+    public function rules()
+    {
+        return [
+            [['aaguid', 'theme', 'mime_type', 'data', 'created_at', 'updated_at'], 'required'],
+            [['aaguid', 'data'], 'string'],
+            [['created_at', 'updated_at'], 'safe'],
+            [['theme'], 'string', 'max' => 8],
+            [['mime_type'], 'string', 'max' => 32],
+            [['aaguid', 'theme'], 'unique', 'targetAttribute' => ['aaguid', 'theme']],
+            [['aaguid'], 'exist', 'skipOnError' => true, 'targetClass' => PasskeyAaguid::class, 'targetAttribute' => ['aaguid' => 'aaguid']],
+        ];
+    }
+
+    #[Override]
+    public function attributeLabels()
+    {
+        return [
+            'aaguid' => 'Aaguid',
+            'theme' => 'Theme',
+            'mime_type' => 'Mime Type',
+            'data' => 'Data',
+            'created_at' => 'Created At',
+            'updated_at' => 'Updated At',
+        ];
+    }
+
+    public function getAagu(): ActiveQuery
+    {
+        return $this->hasOne(PasskeyAaguid::class, ['aaguid' => 'aaguid']);
+    }
+}

--- a/tests/unit/helpers/DataUriTest.php
+++ b/tests/unit/helpers/DataUriTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace tests\helpers;
+
+use Codeception\Test\Unit;
+use app\components\helpers\DataUri;
+
+use function base64_encode;
+
+class DataUriTest extends Unit
+{
+    public function testParsePngBase64(): void
+    {
+        $binary = "\x89PNG\r\n\x1a\n";
+        $uri = 'data:image/png;base64,' . base64_encode($binary);
+        $this->assertSame(['image/png', $binary], DataUri::parse($uri));
+    }
+
+    public function testParseSvgBase64WithPlusInSubtype(): void
+    {
+        $binary = '<svg xmlns="http://www.w3.org/2000/svg"></svg>';
+        $uri = 'data:image/svg+xml;base64,' . base64_encode($binary);
+        $this->assertSame(['image/svg+xml', $binary], DataUri::parse($uri));
+    }
+
+    public function testParseLowercasesMimeType(): void
+    {
+        $uri = 'data:Image/PNG;base64,' . base64_encode('x');
+        $result = DataUri::parse($uri);
+        $this->assertNotNull($result);
+        $this->assertSame('image/png', $result[0]);
+    }
+
+    public function testParseEmptyStringReturnsNull(): void
+    {
+        $this->assertNull(DataUri::parse(''));
+    }
+
+    public function testParseNonDataUriReturnsNull(): void
+    {
+        $this->assertNull(DataUri::parse('https://example.com/icon.png'));
+    }
+
+    public function testParseRejectsNonBase64Encoding(): void
+    {
+        // Plain (URL-encoded) data URI is unsupported by this parser.
+        $this->assertNull(DataUri::parse('data:text/plain,Hello%20World'));
+    }
+
+    public function testParseRejectsCorruptBase64(): void
+    {
+        $this->assertNull(DataUri::parse('data:image/png;base64,!!!not-base64!!!'));
+    }
+}

--- a/views/user/passkey.php
+++ b/views/user/passkey.php
@@ -22,6 +22,7 @@ use yii\web\View;
  * @var User $user
  * @var UserPasskey[] $passkeys
  * @var View $this
+ * @var array<string, array{name: string, mime_type: ?string, base64_data: ?string}> $aaguidInfo
  */
 
 $title = Yii::t('app-passkey', 'Passkeys');
@@ -83,6 +84,7 @@ $transportsOf = function (UserPasskey $p): array {
       <table class="table table-striped">
         <thead>
           <tr>
+            <th></th>
             <th><?= Html::encode(Yii::t('app-passkey', 'Nickname')) ?></th>
             <th><?= Html::encode(Yii::t('app-passkey', 'Transports')) ?></th>
             <th><?= Html::encode(Yii::t('app-passkey', 'Created At')) ?></th>
@@ -93,8 +95,23 @@ $transportsOf = function (UserPasskey $p): array {
         <tbody>
           <?php
           $fmt = Yii::$app->formatter;
-          foreach ($passkeys as $passkey) : ?>
+          foreach ($passkeys as $passkey) :
+            $info = $aaguidInfo[$passkey->aaguid] ?? null;
+          ?>
             <tr>
+              <td>
+                <?php if ($info !== null && $info['mime_type'] !== null && $info['base64_data'] !== null) : ?>
+                  <?= Html::img(
+                    sprintf('data:%s;base64,%s', $info['mime_type'], $info['base64_data']),
+                    [
+                      'class' => 'auto-tooltip',
+                      'title' => $info['name'],
+                      'alt' => '',
+                      'style' => 'height:2em;width:auto',
+                    ],
+                  ) . "\n" ?>
+                <?php endif ?>
+              </td>
               <td><?= Html::encode($passkey->nickname) ?></td>
               <td><?= Html::encode(implode(', ', $transportsOf($passkey))) ?></td>
               <td><?= Html::encode($fmt->asDatetime($passkey->created_at, 'medium')) ?></td>


### PR DESCRIPTION
### **User description**
- Add `passkey_aaguid` and `passkey_aaguid_icon` tables to hold AAGUID metadata (vendor/model name and light/dark icons as MIME type + binary)
- Add `./yii passkey-aaguid` command to sync metadata from passkeydeveloper/passkey-authenticator-aaguids; idempotent and skips when the source JSON is empty
- Display the authenticator icon (theme-matching variant) at the start of each row on /user/passkey, with the model name as the tooltip


___

### **PR Type**
enhancement, tests


___

### **Description**
- パスキー認証デバイスのアイコン表示機能を追加

- AAGUIDメタデータ管理用テーブルと同期コマンドを実装

- ユーザーのパスキーリストにデバイスアイコンを表示

- Data URIパース機能を追加しテストを実装


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["AAGUIDデータ取得"] -- "./yii passkey-aaguid" --> B["DB保存"]
  B -- "JOINクエリ" --> C["パスキー一覧表示"]
  D["DataUriヘルパー"] -- "アイコン解析" --> B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>PasskeyAction.php</strong><dd><code>AAGUID情報の取得とビューへの渡し方を実装</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fetus-hina/stat.ink/pull/1732/files#diff-79cea02f717add205f6c4c6ca6f214e548ba6a5802534ea3a9c687ce0e10f015">+35/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>PasskeyAaguidController.php</strong><dd><code>AAGUIDメタデータ同期コマンドを実装</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fetus-hina/stat.ink/pull/1732/files#diff-034a3c1fcb6ceed8fdac356ac6962e57ecb2cfbf6a3ad79d9e002f29240a87fb">+186/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>DataUri.php</strong><dd><code>Data URIパース機能を追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fetus-hina/stat.ink/pull/1732/files#diff-cb10f6af8aa9cd07a6ca318d3a7fa46ac01f4b8e116337aacf00fc0660a17f54">+38/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>PasskeyAaguid.php</strong><dd><code>AAGUIDモデルクラスを定義</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fetus-hina/stat.ink/pull/1732/files#diff-f9f7e06eff178c92f3feea4cefe7bf482aa338b3bc2227783191632504b467c7">+60/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>PasskeyAaguidIcon.php</strong><dd><code>AAGUIDアイコンモデルクラスを定義</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fetus-hina/stat.ink/pull/1732/files#diff-2faae76d1ddd9fac1bf8d2e532d6f43232e5e7e0dcfbff5614ff18d9a9f81b47">+67/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>passkey.php</strong><dd><code>パスキー一覧にアイコン表示を追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fetus-hina/stat.ink/pull/1732/files#diff-7ac269a558f76df38dac9d3fdccfb1ee537aefdcb07c7a8f440e215d8504e5a5">+18/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Database schema</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>m260503_170504_passkey_aaguid.php</strong><dd><code>AAGUID関連テーブルを作成するマイグレーション</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fetus-hina/stat.ink/pull/1732/files#diff-7728bd1468e076a3ebbe06517c6088493b80b1d1b421a73ac7098d9888df49c7">+69/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>DataUriTest.php</strong><dd><code>DataUriヘルパーのテストを実装</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fetus-hina/stat.ink/pull/1732/files#diff-37c73ae829bba4c475aa52d53aea6839a83c4928c2127df5db7399d2e022acbd">+56/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

