### PR TITLE
Show a loading overlay during passkey login

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,7 @@ RESOURCE_TARGETS := \
 	resources/.compiled/stat.ink/os-icon-widget.js \
 	resources/.compiled/stat.ink/paintball.css \
 	resources/.compiled/stat.ink/passkey-login-navbar.js \
+	resources/.compiled/stat.ink/passkey-login.css \
 	resources/.compiled/stat.ink/passkey-login.js \
 	resources/.compiled/stat.ink/passkey.js \
 	resources/.compiled/stat.ink/permalink-dialog.js \
@@ -335,6 +336,7 @@ resources/.compiled/stat.ink/main.css: resources/stat.ink/main.scss node_modules
 resources/.compiled/stat.ink/os-icon-widget.js: resources/stat.ink/os-icon-widget.es node_modules
 resources/.compiled/stat.ink/paintball.css: resources/stat.ink/paintball.scss node_modules
 resources/.compiled/stat.ink/passkey-login-navbar.js: resources/stat.ink/passkey-login-navbar.es node_modules
+resources/.compiled/stat.ink/passkey-login.css: resources/stat.ink/passkey-login.scss node_modules
 resources/.compiled/stat.ink/passkey-login.js: resources/stat.ink/passkey-login.es node_modules
 resources/.compiled/stat.ink/passkey.js: resources/stat.ink/passkey.es node_modules
 resources/.compiled/stat.ink/permalink-dialog.js: resources/stat.ink/permalink-dialog.es node_modules

--- a/assets/PasskeyLoginAsset.php
+++ b/assets/PasskeyLoginAsset.php
@@ -17,10 +17,14 @@ use yii\web\YiiAsset;
 class PasskeyLoginAsset extends AssetBundle
 {
     public $sourcePath = '@app/resources/.compiled/stat.ink';
+    public $css = [
+        'passkey-login.css',
+    ];
     public $js = [
         'passkey-login.js',
     ];
     public $depends = [
+        FontAwesomeAsset::class,
         JqueryAsset::class,
         YiiAsset::class,
     ];

--- a/assets/PasskeyLoginNavbarAsset.php
+++ b/assets/PasskeyLoginNavbarAsset.php
@@ -17,10 +17,14 @@ use yii\web\YiiAsset;
 class PasskeyLoginNavbarAsset extends AssetBundle
 {
     public $sourcePath = '@app/resources/.compiled/stat.ink';
+    public $css = [
+        'passkey-login.css',
+    ];
     public $js = [
         'passkey-login-navbar.js',
     ];
     public $depends = [
+        FontAwesomeAsset::class,
         JqueryAsset::class,
         YiiAsset::class,
     ];

--- a/resources/stat.ink/passkey-login-navbar.es
+++ b/resources/stat.ink/passkey-login-navbar.es
@@ -23,6 +23,24 @@
     return window.btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
   };
 
+  const showOverlay = function () {
+    if ($('#passkey-login-overlay').length === 0) {
+      $('<div>')
+        .attr('id', 'passkey-login-overlay')
+        .addClass('passkey-login-overlay')
+        .append($('<i>').addClass('fas fa-spinner fa-spin passkey-login-overlay__icon'))
+        .appendTo('body');
+    }
+  };
+
+  const setOverlayLoading = function () {
+    $('#passkey-login-overlay').addClass('passkey-login-overlay--loading');
+  };
+
+  const hideOverlay = function () {
+    $('#passkey-login-overlay').remove();
+  };
+
   const postJson = function (config, url, payload) {
     const data = Object.assign({}, payload);
     if (config.csrfParam && config.csrfToken) {
@@ -49,6 +67,8 @@
   };
 
   const signIn = async function (config) {
+    showOverlay();
+
     let options;
     try {
       options = await postJson(config, config.urls.start, {});
@@ -61,12 +81,16 @@
     try {
       assertion = await navigator.credentials.get(convertGetOptions(options));
     } catch (e) {
+      hideOverlay();
       return;
     }
 
     if (!assertion || !assertion.response || !assertion.response.userHandle) {
+      hideOverlay();
       return;
     }
+
+    setOverlayLoading();
 
     try {
       const result = await postJson(config, config.urls.finish, {

--- a/resources/stat.ink/passkey-login.es
+++ b/resources/stat.ink/passkey-login.es
@@ -37,6 +37,24 @@
     $('#passkey-login-message').hide().text('');
   };
 
+  const showOverlay = function () {
+    if ($('#passkey-login-overlay').length === 0) {
+      $('<div>')
+        .attr('id', 'passkey-login-overlay')
+        .addClass('passkey-login-overlay')
+        .append($('<i>').addClass('fas fa-spinner fa-spin passkey-login-overlay__icon'))
+        .appendTo('body');
+    }
+  };
+
+  const setOverlayLoading = function () {
+    $('#passkey-login-overlay').addClass('passkey-login-overlay--loading');
+  };
+
+  const hideOverlay = function () {
+    $('#passkey-login-overlay').remove();
+  };
+
   const isSupported = function () {
     return !!(
       window.PublicKeyCredential &&
@@ -75,7 +93,9 @@
 
     const $button = $('#passkey-login-button');
     $button.prop('disabled', true);
+    showOverlay();
 
+    let success = false;
     try {
       const options = await postJson(config.urls.start, {});
       const credentialOptions = convertGetOptions(options);
@@ -93,6 +113,8 @@
         return;
       }
 
+      setOverlayLoading();
+
       const rememberMe = $('#passkey-login-remember').is(':checked') ? '1' : '0';
       const result = await postJson(config.urls.finish, {
         credential_id: arrayBufferToBase64Url(assertion.rawId),
@@ -104,14 +126,18 @@
       });
 
       if (result && result.result) {
+        success = true;
         window.location.href = config.urls.redirect;
-      } else {
-        showError((result && result.message) || config.messages.loginFailed);
+        return;
       }
+      showError((result && result.message) || config.messages.loginFailed);
     } catch (e) {
       showError((e && e.message) || config.messages.loginFailed);
     } finally {
-      $button.prop('disabled', false);
+      if (!success) {
+        $button.prop('disabled', false);
+        hideOverlay();
+      }
     }
   };
 

--- a/resources/stat.ink/passkey-login.scss
+++ b/resources/stat.ink/passkey-login.scss
@@ -1,0 +1,26 @@
+/*! Copyright (C) 2026 AIZAWA Hina | MIT License */
+
+.passkey-login-overlay {
+  align-items: center;
+  background: rgba(0, 0, 0, 0.4);
+  cursor: wait;
+  display: flex;
+  height: 100%;
+  justify-content: center;
+  left: 0;
+  position: fixed;
+  top: 0;
+  width: 100%;
+  z-index: 9999;
+
+  &__icon {
+    color: #fff;
+    display: none;
+    filter: drop-shadow(0 0 4px rgba(0, 0, 0, 0.5));
+    font-size: 8rem;
+  }
+
+  &--loading &__icon {
+    display: block;
+  }
+}


### PR DESCRIPTION
### **User description**
## Summary

  There is a multi-second delay between the moment a user finishes
  selecting a passkey / entering their PIN and the moment the page
  actually navigates after a successful sign-in. During that window the
  page looks idle and users can reasonably wonder whether the login
  attempt failed.

  To make the in-flight state obvious, this PR adds a translucent
  backdrop the moment the user invokes passkey login. Once the credential
  assertion has been collected from the platform authenticator and the
  `finish` request is in flight, a large opaque spinner is layered on
  top. The overlay is removed if the user cancels the OS prompt or if
  the server rejects the assertion; on success it stays visible until
  the browser navigates away.

  The change covers both the standalone passkey login page and the
  navbar passkey login button.

  ## Implementation notes

  - Added `resources/stat.ink/passkey-login.scss` with a fixed-position
    backdrop (`z-index: 9999`) and a hidden spinner that becomes visible
    via a `--loading` modifier class.
  - Added `passkey-login.css` to `PasskeyLoginAsset` and
    `PasskeyLoginNavbarAsset`, and pulled in `FontAwesomeAsset` so the
    navbar entry point also has access to the spinner glyph.
  - Both `passkey-login.es` and `passkey-login-navbar.es` now manage the
    overlay lifecycle: show on click, switch to the spinning state once
    `navigator.credentials.get()` resolves, hide on any non-success path,
    and leave it up while the redirect is happening.


___

### **PR Type**
Enhancement


___

### **Description**
- パスキー認証中にローディングオーバーレイを表示する機能を追加

- 成功時のリダイレクト中もオーバーレイを維持し、ユーザーにフィードバックを提供

- ログイン失敗時やキャンセル時はオーバーレイを非表示にすることでUXを改善

- スタイルシートとアセットの依存関係にFontAwesomeを追加してスピナーを表示


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["User clicks login"] --> B["Show overlay"]
  B --> C["Get credentials"]
  C --> D{"Success?"}
  D -->|Yes| E["Set loading state"]
  E --> F["Redirect & keep overlay"]
  D -->|No| G["Hide overlay"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PasskeyLoginAsset.php</strong><dd><code>アセット定義にCSSとFontAwesomeを追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

assets/PasskeyLoginAsset.php

- CSSファイルとして`passkey-login.css`を追加
- 依存関係に`FontAwesomeAsset`を追加


</details>


  </td>
  <td><a href="https://github.com/fetus-hina/stat.ink/pull/1735/files#diff-4a00157d6bd9f45b7ec1c9938a32213815fc7204a7dc2dc84d35876bf20d698a">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>PasskeyLoginNavbarAsset.php</strong><dd><code>ナビバー用アセットにもCSSとFontAwesomeを追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

assets/PasskeyLoginNavbarAsset.php

- CSSファイルとして`passkey-login.css`を追加
- 依存関係に`FontAwesomeAsset`を追加


</details>


  </td>
  <td><a href="https://github.com/fetus-hina/stat.ink/pull/1735/files#diff-5c39f52e03057f7261d61ed707a06c4e12f69ab26381f7215e760cad3edf64eb">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>passkey-login.scss</strong><dd><code>パスキー認証オーバーレイのスタイルを追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

resources/stat.ink/passkey-login.scss

- オーバーレイ要素のスタイルを定義
- ローディング状態でのスピナー表示に関するスタイルを追加


</details>


  </td>
  <td><a href="https://github.com/fetus-hina/stat.ink/pull/1735/files#diff-d6c9379434ab402c0f050d43c2caaefc725c2620706550caff6b688428f066c4">+26/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>passkey-login-navbar.es</strong><dd><code>ナビバー用JSにオーバーレイ制御を実装</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

resources/stat.ink/passkey-login-navbar.es

<ul><li>オーバーレイ操作関数（表示・ローディング状態設定・非表示）を追加<br> <li> 認証処理開始時にオーバーレイを表示し、成功時にはローディング状態へ遷移<br> <li> 失敗またはキャンセル時はオーバーレイを削除</ul>


</details>


  </td>
  <td><a href="https://github.com/fetus-hina/stat.ink/pull/1735/files#diff-e5dd9dc809ef065f6544568c0bd7a5c5440ddcf83f97559e672f9b54da8c11d6">+24/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>passkey-login.es</strong><dd><code>メインログインページ用JSにオーバーレイ制御を実装</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

resources/stat.ink/passkey-login.es

<ul><li>オーバーレイ操作関数（表示・ローディング状態設定・非表示）を追加<br> <li> ログインボタン押下時にオーバーレイを表示し、認証成功後はリダイレクト完了まで保持<br> <li> エラー発生時はオーバーレイを削除し、ボタンを再度有効化</ul>


</details>


  </td>
  <td><a href="https://github.com/fetus-hina/stat.ink/pull/1735/files#diff-fd8c8230d0ac978dfc430964fc810ff3720ea4f72965484865198d4fa8dd0b55">+29/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Build system</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Makefile</strong><dd><code>CSSコンパイルターゲットを更新</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Makefile

- コンパイル対象に`passkey-login.css`を追加
- SCSSからCSSへの変換ルールを追加


</details>


  </td>
  <td><a href="https://github.com/fetus-hina/stat.ink/pull/1735/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

