### PR TITLE
Add favorite weapons section to the create-battle3 dialog

### DIFF
--- a/components/widgets/v3/CreateBattleWidget.php
+++ b/components/widgets/v3/CreateBattleWidget.php
@@ -17,6 +17,7 @@ use app\components\widgets\Icon;
 use app\models\Lobby3;
 use app\models\Map3;
 use app\models\Rule3;
+use app\models\UserWeapon3;
 use app\models\Weapon3;
 use app\models\WeaponType3;
 use yii\helpers\ArrayHelper;
@@ -30,6 +31,7 @@ use function implode;
 use function sprintf;
 
 use const SORT_ASC;
+use const SORT_DESC;
 use const SORT_LOCALE_STRING;
 use const SORT_NATURAL;
 
@@ -288,6 +290,12 @@ final class CreateBattleWidget extends Dialog
         );
 
         $result = ['' => Yii::t('app', 'Unknown')];
+
+        $favorites = $this->makeFavoriteWeapons();
+        if ($favorites !== []) {
+            $result[Yii::t('app', 'Favorite Weapons')] = $favorites;
+        }
+
         foreach (WeaponType3::find()->orderBy(['rank' => SORT_ASC])->all() as $type) {
             $typeWeapons = ArrayHelper::asort(
                 ArrayHelper::getValue($weapons, $type->id, []),
@@ -299,6 +307,37 @@ final class CreateBattleWidget extends Dialog
         }
 
         return $result;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function makeFavoriteWeapons(): array
+    {
+        $user = Yii::$app->user->identity;
+        if (!$user) {
+            return [];
+        }
+
+        $list = UserWeapon3::find()
+            ->with(['weapon'])
+            ->andWhere(['{{%user_weapon3}}.[[user_id]]' => $user->id])
+            ->orderBy([
+                'battles' => SORT_DESC,
+                'last_used_at' => SORT_DESC,
+                'weapon_id' => SORT_DESC,
+            ])
+            ->limit(10)
+            ->all();
+        if (!$list) {
+            return [];
+        }
+
+        return ArrayHelper::map(
+            $list,
+            'weapon.key',
+            fn (UserWeapon3 $model): string => Yii::t('app-weapon3', $model->weapon->name),
+        );
     }
 
     private function renderResultButtonGroup(): string


### PR DESCRIPTION
### **User description**
## Summary
  - Prepend a "Favorite Weapons" optgroup at the top of the weapon `<select>` in the Splatoon 3 manual battle
  registration dialog (`CreateBattleWidget`).
  - Favorites are the top 10 entries from `user_weapon3` for the logged-in user, ordered by `battles DESC,
  last_used_at DESC, weapon_id DESC` — matching the existing `WeaponDropdownListTrait` behavior used in the battle
  filter dropdown.
  - The full type-grouped weapon list still follows, with favorited weapons intentionally left in place there too, so
  muscle-memory navigation isn't broken.
  - Falls back to the original behavior when the user is a guest or has no `user_weapon3` rows.


___

### **PR Type**
enhancement


___

### **Description**
- お気に入り武器セクションを手動バトル登録ダイアログに追加

- ログインユーザーの上位10件のお気に入り武器を表示

- 既存の武器リストには影響せず、そのまま表示される

- ゲストユーザーやデータなしの場合、従来の動作に戻る


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CreateBattleWidget"] -- "お気に入り武器取得" --> B["UserWeapon3"]
  A -- "武器リスト生成" --> C["Weapon3"]
  A -- "表示" --> D["ダイアログUI"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CreateBattleWidget.php</strong><dd><code>お気に入り武器機能の追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

components/widgets/v3/CreateBattleWidget.php

<ul><li><code>UserWeapon3</code>モデルのインポートを追加<br> <li> <code>SORT_DESC</code>定数のインポートを追加<br> <li> <code>makeWeapons()</code>メソッドにお気に入り武器セクションを追加<br> <li> 新しい<code>makeFavoriteWeapons()</code>メソッドを実装</ul>


</details>


  </td>
  <td><a href="https://github.com/fetus-hina/stat.ink/pull/1741/files#diff-a178ebf529da7ec6f6264bb92699f052ff4204048bbb68510adeb26d08a2a9bc">+39/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

