### PR TITLE
Enable s3-img-gen thumbnails for tricolor battles

### DIFF
--- a/actions/api/internal/latestBattles/Battle3Formatter.php
+++ b/actions/api/internal/latestBattles/Battle3Formatter.php
@@ -56,12 +56,7 @@ trait Battle3Formatter
             );
         }
 
-        $rule = $model->rule;
-        if (
-            $rule &&
-            $rule->key !== 'tricolor' &&
-            ArrayHelper::getValue(Yii::$app->params, 'useS3ImgGen')
-        ) {
+        if (ArrayHelper::getValue(Yii::$app->params, 'useS3ImgGen')) {
             return vsprintf('https://s3-img-gen.stats.ink/results/%s/%s.jpg', [
                 rawurlencode(Yii::$app->language),
                 rawurlencode($model->uuid),
@@ -87,13 +82,10 @@ trait Battle3Formatter
         }
 
         if (ArrayHelper::getValue(Yii::$app->params, 'useS3ImgGen')) {
-            $rule = $model->rule;
-            if ($rule && $rule->key !== 'tricolor') {
-                return vsprintf('https://s3-img-gen.stats.ink/results/thumb-<w>x<h>/%s/%s.jpg', [
-                    rawurlencode(Yii::$app->language),
-                    rawurlencode($model->uuid),
-                ]);
-            }
+            return vsprintf('https://s3-img-gen.stats.ink/results/thumb-<w>x<h>/%s/%s.jpg', [
+                rawurlencode(Yii::$app->language),
+                rawurlencode($model->uuid),
+            ]);
         }
 
         return null;


### PR DESCRIPTION
### **User description**
## Summary

  - s3-img-gen now supports tricolor battles, so drop the tricolor-specific bypass on the latest-battles list shown on
   the top page.
  - Removed the `$rule->key !== 'tricolor'` guard from `Battle3Formatter::image3()` and `thumb3()` so tricolor battles
   use s3-img-gen the same way as other rules.

  Fixes #1174


___

### **PR Type**
Enhancement


___

### **Description**
- トリカラバトルの画像生成に対応するため、s3-img-genの利用制限を解除

- 最新バトル一覧でトリカラバトルにもサムネイル画像が表示されるように改善

- `Battle3Formatter`クラス内の`s3-img-gen`利用条件からトリカラルール除外を削除


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Battle3Formatter::image3()"] -- "s3-img-gen利用条件変更" --> B["トリカラ含む全ルールでs3-img-gen使用"]
  C["Battle3Formatter::thumb3()"] -- "同様に条件変更" --> B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Battle3Formatter.php</strong><dd><code>トリカラバトル対応のためs3-img-gen制限解除</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

actions/api/internal/latestBattles/Battle3Formatter.php

<ul><li><code>image3()</code>メソッドからトリカラルール除外ロジックを削除し、全ルールでs3-img-genを使用可能に<br> <li> <code>thumb3()</code>メソッドからも同様にトリカラ除外処理を削除<br> <li> s3-img-genの利用フラグ確認のみに統一し、ルールによる分岐を簡略化</ul>


</details>


  </td>
  <td><a href="https://github.com/fetus-hina/stat.ink/pull/1742/files#diff-1c562bc59a161f5b5278bcddd8355e13875d0da38d54a87c8e904cdc550ab590">+5/-13</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

