### PR TITLE
Use ::class constant for SiteController asset bundles

### DIFF
--- a/controllers/SiteController.php
+++ b/controllers/SiteController.php
@@ -14,8 +14,23 @@ use app\actions\site\SimpleAction;
 use app\actions\site\StartAction;
 use app\components\web\AssetPublishAction;
 use app\components\web\Controller;
+use jp3cki\yii2\datetimepicker\BootstrapDateTimePickerAsset;
+use jp3cki\yii2\flot\FlotAsset;
+use jp3cki\yii2\flot\FlotPieAsset;
+use jp3cki\yii2\flot\FlotResizeAsset;
+use jp3cki\yii2\flot\FlotStackAsset;
+use jp3cki\yii2\flot\FlotSymbolAsset;
+use jp3cki\yii2\flot\FlotTimeAsset;
+use jp3cki\yii2\zxcvbn\ZxcvbnAsset;
+use statink\yii2\anonymizer\AnonymizerAsset;
+use statink\yii2\sortableTable\SortableTableAsset;
+use statink\yii2\twitter\webintents\TwitterWebIntentsAsset;
+use yii\bootstrap\BootstrapAsset;
+use yii\bootstrap\BootstrapPluginAsset;
 use yii\filters\AccessControl;
 use yii\web\ErrorAction;
+use yii\web\JqueryAsset;
+use yii\web\YiiAsset;
 
 use function defined;
 use function implode;
@@ -47,23 +62,22 @@ class SiteController extends Controller
             ],
             'asset-publish' => [
                 'class' => AssetPublishAction::class,
-                //FIXME!!!!!!!!!!!!!!!!
                 'classes' => [
-                    'jp3cki\yii2\datetimepicker\BootstrapDateTimePickerAsset',
-                    'jp3cki\yii2\flot\FlotAsset',
-                    'jp3cki\yii2\flot\FlotPieAsset',
-                    'jp3cki\yii2\flot\FlotResizeAsset',
-                    'jp3cki\yii2\flot\FlotStackAsset',
-                    'jp3cki\yii2\flot\FlotSymbolAsset',
-                    'jp3cki\yii2\flot\FlotTimeAsset',
-                    'jp3cki\yii2\zxcvbn\ZxcvbnAsset',
-                    'statink\yii2\anonymizer\AnonymizerAsset',
-                    'statink\yii2\sortableTable\SortableTableAsset',
-                    'statink\yii2\twitter\webintents\TwitterWebIntentsAsset',
-                    'yii\bootstrap\BootstrapAsset',
-                    'yii\bootstrap\BootstrapPluginAsset',
-                    'yii\web\JqueryAsset',
-                    'yii\web\YiiAsset',
+                    AnonymizerAsset::class,
+                    BootstrapAsset::class,
+                    BootstrapDateTimePickerAsset::class,
+                    BootstrapPluginAsset::class,
+                    FlotAsset::class,
+                    FlotPieAsset::class,
+                    FlotResizeAsset::class,
+                    FlotStackAsset::class,
+                    FlotSymbolAsset::class,
+                    FlotTimeAsset::class,
+                    JqueryAsset::class,
+                    SortableTableAsset::class,
+                    TwitterWebIntentsAsset::class,
+                    YiiAsset::class,
+                    ZxcvbnAsset::class,
                 ],
             ],
             'index' => [


### PR DESCRIPTION
### **User description**
## Summary
- Replace 15 FQCN string literals in `SiteController::actions()`'s `asset-publish` `classes` array with the `::class` constant, backed by explicit `use` statements.
- Sort the entries alphabetically by short class name (independent of namespace).
- Drop a stale `//FIXME!!!!!!!!!!!!!!!!` comment that this change resolves.

## Test plan
- [x] `php -l controllers/SiteController.php`
- [x] `vendor/bin/phpcs controllers/SiteController.php`
- [ ] CI green


___

### **PR Type**
enhancement


___

### **Description**
- `::class` 定数を使用するようにアセットバンドルの指定を変更

- FQCN 文字列リテラルからクラス定数への置換を実施

- アセットクラスのリストを短いクラス名でアルファベット順にソート

- 古い FIXME コメントを削除


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["FQCN strings"] -- "変換" --> B["::class constants"]
  C["FIXMEコメント"] -- "削除" --> D["クリーンコード"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SiteController.php</strong><dd><code>アセットバンドル定義のリファクタリング</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

controllers/SiteController.php

<ul><li><code>use</code> ステートメントを追加して関連アセットクラスをインポート<br> <li> <code>asset-publish</code> アクションの <code>classes</code> 配列で <code>::class</code> 定数を使用するよう変更<br> <li> クラスリストを短いクラス名のアルファベット順に並び替え<br> <li> 不要な FIXME コメントを削除</ul>


</details>


  </td>
  <td><a href="https://github.com/fetus-hina/stat.ink/pull/1749/files#diff-b891c267b4690db516a37a8d85e608934910633223cec2ec5d186ec1d6e192cb">+30/-16</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

