### PR TITLE
Sort tricolor teams by attacker/defender side

### DIFF
--- a/views/show-v3/battle/players/players.php
+++ b/views/show-v3/battle/players/players.php
@@ -45,6 +45,55 @@ if (
   $isXMR = true;
 }
 
+$ourSet = [
+  'color' => $battle->our_team_color,
+  'role' => $battle->ourTeamRole,
+  'theme' => $battle->ourTeamTheme,
+  'players' => $ourTeamPlayers,
+  'ourTeam' => true,
+];
+$theirSet = [
+  'color' => $battle->their_team_color,
+  'role' => $battle->theirTeamRole,
+  'theme' => $battle->theirTeamTheme,
+  'players' => $theirTeamPlayers,
+  'ourTeam' => false,
+];
+$thirdSet = [
+  'color' => $battle->third_team_color,
+  'role' => $battle->thirdTeamRole,
+  'theme' => $battle->thirdTeamTheme,
+  'players' => $thirdTeamPlayers,
+  'ourTeam' => false,
+];
+
+// Build the display order. For tricolor battles, if there is another team
+// on the same side (attacker/defender) as ours, group it next to our team
+// so that "our group" stays together and our team is always first within it.
+// When no same-side other team exists (i.e. we are the lone defender), keep
+// the legacy ordering. Non-tricolor battles are also unaffected.
+if ($isTricolor) {
+  $ourRoleKey = $battle->ourTeamRole?->key;
+  $theirSame = $ourRoleKey !== null && $battle->theirTeamRole?->key === $ourRoleKey;
+  $thirdSame = $ourRoleKey !== null && $battle->thirdTeamRole?->key === $ourRoleKey;
+
+  if ($theirSame || $thirdSame) {
+    $sameSet = $theirSame ? $theirSet : $thirdSet;
+    $oppositeSet = $theirSame ? $thirdSet : $theirSet;
+    $displayOrder = $ourTeamFirst
+      ? [$ourSet, $sameSet, $oppositeSet]
+      : [$oppositeSet, $ourSet, $sameSet];
+  } else {
+    $displayOrder = $ourTeamFirst
+      ? [$ourSet, $theirSet, $thirdSet]
+      : [$thirdSet, $theirSet, $ourSet];
+  }
+} else {
+  $displayOrder = $ourTeamFirst
+    ? [$ourSet, $theirSet]
+    : [$theirSet, $ourSet];
+}
+
 ?>
 <div class="table-responsive table-responsive-force mb-3">
   <table class="table table-bordered mb-0" id="players">
@@ -92,93 +141,18 @@ if (
       </tr>
     </thead>
     <tbody>
-<?php if ($ourTeamFirst) { ?>
+<?php foreach ($displayOrder as $set) { ?>
       <?= $this->render('//show-v3/battle/players/team', [
         'abilities' => $abilities,
         'battle' => $battle,
-        'color' => $battle->our_team_color,
+        'color' => $set['color'],
         'isTricolor' => $isTricolor,
         'isXmatch' => $isXmatch,
-        'ourTeam' => true,
+        'ourTeam' => $set['ourTeam'],
         'playedWith' => $playedWith,
-        'players' => $ourTeamPlayers,
-        'role' => $battle->ourTeamRole,
-        'theme' => $battle->ourTeamTheme,
-        'useXMatchingRange' => $isXMR,
-        'weaponMatchingGroup' => $weaponMatchingGroup,
-      ]) . "\n" ?>
-      <?= $this->render('//show-v3/battle/players/team', [
-        'abilities' => $abilities,
-        'battle' => $battle,
-        'color' => $battle->their_team_color,
-        'isTricolor' => $isTricolor,
-        'isXmatch' => $isXmatch,
-        'ourTeam' => false,
-        'playedWith' => $playedWith,
-        'players' => $theirTeamPlayers,
-        'role' => $battle->theirTeamRole,
-        'theme' => $battle->theirTeamTheme,
-        'useXMatchingRange' => $isXMR,
-        'weaponMatchingGroup' => $weaponMatchingGroup,
-      ]) . "\n" ?>
-<?php if ($isTricolor) { ?>
-      <?= $this->render('//show-v3/battle/players/team', [
-        'abilities' => $abilities,
-        'battle' => $battle,
-        'color' => $battle->third_team_color,
-        'isTricolor' => $isTricolor,
-        'isXmatch' => $isXmatch,
-        'ourTeam' => false,
-        'playedWith' => $playedWith,
-        'players' => $thirdTeamPlayers,
-        'role' => $battle->thirdTeamRole,
-        'theme' => $battle->thirdTeamTheme,
-        'useXMatchingRange' => $isXMR,
-        'weaponMatchingGroup' => $weaponMatchingGroup,
-      ]) . "\n" ?>
-<?php } ?>
-<?php } else { ?>
-<?php if ($isTricolor) { ?>
-      <?= $this->render('//show-v3/battle/players/team', [
-        'abilities' => $abilities,
-        'battle' => $battle,
-        'color' => $battle->third_team_color,
-        'isTricolor' => $isTricolor,
-        'isXmatch' => $isXmatch,
-        'ourTeam' => true,
-        'playedWith' => $playedWith,
-        'players' => $thirdTeamPlayers,
-        'role' => $battle->thirdTeamRole,
-        'theme' => $battle->thirdTeamTheme,
-        'useXMatchingRange' => $isXMR,
-        'weaponMatchingGroup' => $weaponMatchingGroup,
-      ]) . "\n" ?>
-<?php } ?>
-      <?= $this->render('//show-v3/battle/players/team', [
-        'abilities' => $abilities,
-        'battle' => $battle,
-        'color' => $battle->their_team_color,
-        'isTricolor' => $isTricolor,
-        'isXmatch' => $isXmatch,
-        'ourTeam' => false,
-        'playedWith' => $playedWith,
-        'players' => $theirTeamPlayers,
-        'role' => $battle->theirTeamRole,
-        'theme' => $battle->theirTeamTheme,
-        'useXMatchingRange' => $isXMR,
-        'weaponMatchingGroup' => $weaponMatchingGroup,
-      ]) . "\n" ?>
-      <?= $this->render('//show-v3/battle/players/team', [
-        'abilities' => $abilities,
-        'battle' => $battle,
-        'color' => $battle->our_team_color,
-        'isTricolor' => $isTricolor,
-        'isXmatch' => $isXmatch,
-        'ourTeam' => true,
-        'playedWith' => $playedWith,
-        'players' => $ourTeamPlayers,
-        'role' => $battle->ourTeamRole,
-        'theme' => $battle->ourTeamTheme,
+        'players' => $set['players'],
+        'role' => $set['role'],
+        'theme' => $set['theme'],
         'useXMatchingRange' => $isXMR,
         'weaponMatchingGroup' => $weaponMatchingGroup,
       ]) . "\n" ?>


### PR DESCRIPTION
### **User description**
## Summary

- In tricolor battles, the three teams were rendered as `our → their → third` regardless of attacker/defender alignment. Since the order of the three teams in the API payload is at the client's discretion, this could place an opposite-side team between our team and the other team on our own side.
- Group our team with the other team that shares our attacker/defender side. Within that group, our team is always first, regardless of win/loss. The opposite-side team is rendered on the far end. Group order itself still follows the existing win/loss flip.
- When we are the lone defender (i.e. both other teams are on the opposite side), there is no other team on our side, so the legacy `our → their → third` / `third → their → our` ordering is preserved. Non-tricolor battles are also unaffected.

Resulting order (tricolor, attacker side with a same-side ally):

| Our role | Their role | Third role | Win  | Order              |
| -------- | ---------- | ---------- | ---- | ------------------ |
| attacker | defender   | attacker   | win  | our → third → their |
| attacker | defender   | attacker   | lose | their → our → third |
| attacker | attacker   | defender   | win  | our → their → third |
| attacker | attacker   | defender   | lose | third → our → their |

Fixes #1169
Refs #1107

## Test plan

- [ ] Open a tricolor battle detail page where the same-side ally is `third` and verify the team table renders `our → third → their` on a win.
- [ ] Open a tricolor battle detail page where the same-side ally is `third` and confirm the lose case renders `their → our → third`.
- [ ] Open a tricolor battle detail page where our team is the defender and confirm the legacy ordering still applies for both win and lose.
- [ ] Open a regular 4v4 battle detail page and confirm two-team display is unchanged.


___

### **PR Type**
enhancement


___

### **Description**
- トリカラバトルでのチーム表示順序を攻撃側/防御側に基づいて並び替え

- 勝敗にかかわらず自チームを同じサイドのチームとグループ化し、常に先頭に表示

- 同じサイドのチームがいない場合（例：自分が唯一の防御側）は従来の表示順序を維持

- 非トリカラバトルへの影響なし


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Battle Data"] -- "Determine Roles" --> B["Team Role Analysis"]
  B -- "Same Side Exists" --> C["Group Same-Side Teams"]
  B -- "Lone Defender" --> D["Legacy Ordering"]
  C -- "Render Teams" --> E["Display Order Applied"]
  D -- "Render Teams" --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>players.php</strong><dd><code>チーム表示順序の動的制御と描画処理のリファクタリング</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

views/show-v3/battle/players/players.php

<ul><li>自チーム、相手チーム、第3チームの情報を配列に格納し、表示順序を動的に決定する処理を追加<br> <li> トリカラバトルにおいて、自チームと同じサイド（攻撃/防御）のチームを隣接させる新しい表示ロジックを実装<br> <li> チーム描画部分をループ処理に変更し、動的な表示順に対応<br> <li> 従来の条件分岐によるチーム描画コードを削除</ul>


</details>


  </td>
  <td><a href="https://github.com/fetus-hina/stat.ink/pull/1762/files#diff-3c063a9f279f1c8d6dbdfc4cb7b34ee3373a1c79bef76018c6ec3a9e49cf9f90">+55/-81</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

