### PR TITLE
Speed up /entire/weapons2 and tidy its term filter

### DIFF
--- a/actions/entire/Weapons2Action.php
+++ b/actions/entire/Weapons2Action.php
@@ -11,18 +11,17 @@ namespace app\actions\entire;
 
 use DateInterval;
 use DateTime;
-use DateTimeImmutable;
 use DateTimeZone;
 use Exception;
 use Throwable;
 use Yii;
-use app\components\helpers\Battle as BattleHelper;
+use app\components\helpers\YearMonth;
 use app\models\EntireWeapon2Form;
 use app\models\Rule2;
 use app\models\Special2;
 use app\models\SplatoonVersion2;
 use app\models\SplatoonVersionGroup2;
-use app\models\StatWeapon2UseCount;
+use app\models\StatWeapon2UseCountPerMonth;
 use app\models\Subweapon2;
 use app\models\Weapon2;
 use stdClass;
@@ -189,59 +188,59 @@ class Weapons2Action extends BaseAction
             'type_name' => 'MAX({{weapon_type2}}.[[name]])',
             'category_key' => 'MAX({{weapon_category2}}.[[key]])',
             'category_name' => 'MAX({{weapon_category2}}.[[name]])',
-            'count' => 'SUM({{stat_weapon2_use_count}}.[[battles]])',
+            'count' => 'SUM({{stat_weapon2_use_count_per_month}}.[[battles]])',
             'avg_kill' => sprintf(
                 '(%s / NULLIF(%s, 0))',
-                'SUM({{stat_weapon2_use_count}}.[[kills]])',
-                'SUM({{stat_weapon2_use_count}}.[[kd_available]])',
+                'SUM({{stat_weapon2_use_count_per_month}}.[[kills]])',
+                'SUM({{stat_weapon2_use_count_per_month}}.[[kd_available]])',
             ),
-            'sum_kill' => 'SUM({{stat_weapon2_use_count}}.[[kills]])',
+            'sum_kill' => 'SUM({{stat_weapon2_use_count_per_month}}.[[kills]])',
             'kill_per_min' => sprintf(
                 '(%s * 60.0 / NULLIF(%s, 0))',
-                'SUM({{stat_weapon2_use_count}}.[[kills_with_time]])',
-                'SUM({{stat_weapon2_use_count}}.[[kd_time_seconds]])',
+                'SUM({{stat_weapon2_use_count_per_month}}.[[kills_with_time]])',
+                'SUM({{stat_weapon2_use_count_per_month}}.[[kd_time_seconds]])',
             ),
             'avg_death' => sprintf(
                 '(%s / NULLIF(%s, 0))',
-                'SUM({{stat_weapon2_use_count}}.[[deaths]])',
-                'SUM({{stat_weapon2_use_count}}.[[kd_available]])',
+                'SUM({{stat_weapon2_use_count_per_month}}.[[deaths]])',
+                'SUM({{stat_weapon2_use_count_per_month}}.[[kd_available]])',
             ),
-            'sum_death' => 'SUM({{stat_weapon2_use_count}}.[[deaths]])',
+            'sum_death' => 'SUM({{stat_weapon2_use_count_per_month}}.[[deaths]])',
             'death_per_min' => sprintf(
                 '(%s * 60.0 / NULLIF(%s, 0))',
-                'SUM({{stat_weapon2_use_count}}.[[deaths_with_time]])',
-                'SUM({{stat_weapon2_use_count}}.[[kd_time_seconds]])',
+                'SUM({{stat_weapon2_use_count_per_month}}.[[deaths_with_time]])',
+                'SUM({{stat_weapon2_use_count_per_month}}.[[kd_time_seconds]])',
             ),
             'avg_special' => sprintf(
                 '(%s / NULLIF(%s, 0))',
-                'SUM({{stat_weapon2_use_count}}.[[specials]])',
-                'SUM({{stat_weapon2_use_count}}.[[specials_available]])',
+                'SUM({{stat_weapon2_use_count_per_month}}.[[specials]])',
+                'SUM({{stat_weapon2_use_count_per_month}}.[[specials_available]])',
             ),
-            'sum_special' => 'SUM({{stat_weapon2_use_count}}.[[specials]])',
+            'sum_special' => 'SUM({{stat_weapon2_use_count_per_month}}.[[specials]])',
             'special_per_min' => sprintf(
                 '(%s * 60.0 / NULLIF(%s, 0))',
-                'SUM({{stat_weapon2_use_count}}.[[specials_with_time]])',
-                'SUM({{stat_weapon2_use_count}}.[[specials_time_seconds]])',
+                'SUM({{stat_weapon2_use_count_per_month}}.[[specials_with_time]])',
+                'SUM({{stat_weapon2_use_count_per_month}}.[[specials_time_seconds]])',
             ),
             'avg_inked' => sprintf(
                 '(%s / NULLIF(%s, 0))',
-                'SUM({{stat_weapon2_use_count}}.[[inked]])',
-                'SUM({{stat_weapon2_use_count}}.[[inked_available]])',
+                'SUM({{stat_weapon2_use_count_per_month}}.[[inked]])',
+                'SUM({{stat_weapon2_use_count_per_month}}.[[inked_available]])',
             ),
-            'sum_inked' => 'SUM({{stat_weapon2_use_count}}.[[inked]])',
+            'sum_inked' => 'SUM({{stat_weapon2_use_count_per_month}}.[[inked]])',
             'inked_per_min' => sprintf(
                 '(%s * 60.0 / NULLIF(%s, 0))',
-                'SUM({{stat_weapon2_use_count}}.[[inked_with_time]])',
-                'SUM({{stat_weapon2_use_count}}.[[inked_time_seconds]])',
+                'SUM({{stat_weapon2_use_count_per_month}}.[[inked_with_time]])',
+                'SUM({{stat_weapon2_use_count_per_month}}.[[inked_time_seconds]])',
             ),
             'wp' => sprintf(
                 '(%s * 100.0 / NULLIF(%s, 0))',
-                'SUM({{stat_weapon2_use_count}}.[[wins]])',
-                'SUM({{stat_weapon2_use_count}}.[[battles]])',
+                'SUM({{stat_weapon2_use_count_per_month}}.[[wins]])',
+                'SUM({{stat_weapon2_use_count_per_month}}.[[battles]])',
             ),
-            'win_count' => 'SUM({{stat_weapon2_use_count}}.[[wins]])',
+            'win_count' => 'SUM({{stat_weapon2_use_count_per_month}}.[[wins]])',
         ];
-        $query = StatWeapon2UseCount::find()
+        $query = StatWeapon2UseCountPerMonth::find()
             ->select($columns)
             ->innerJoinWith([
                 'weapon',
@@ -250,8 +249,8 @@ class Weapons2Action extends BaseAction
                 'weapon.type',
                 'weapon.type.category',
             ])
-            ->andWhere(['{{stat_weapon2_use_count}}.[[rule_id]]' => $rule->id])
-            ->groupBy('{{stat_weapon2_use_count}}.[[weapon_id]]');
+            ->andWhere(['{{stat_weapon2_use_count_per_month}}.[[rule_id]]' => $rule->id])
+            ->groupBy('{{stat_weapon2_use_count_per_month}}.[[weapon_id]]');
         try {
             if ($form->hasErrors()) {
                 throw new Exception();
@@ -266,17 +265,9 @@ class Weapons2Action extends BaseAction
             if ($form->term == '') {
                 // nothing to do
             } elseif (preg_match('/^(\d{4})-(\d{2})$/', $form->term, $match)) {
-                // [$start, $end)
-                $start = new DateTimeImmutable()
-                    ->setTimeZone(new DateTimeZone('Etc/UTC'))
-                    ->setDate(intval($match[1], 10), intval($match[2], 10), 1)
-                    ->setTime(0, 0, 0);
-                $end = $start->add(new DateInterval('P1M'));
-                $startPeriod = BattleHelper::calcPeriod2($start->getTimestamp());
-                $endPeriod = BattleHelper::calcPeriod2($end->getTimestamp());
-                $query->andWhere(['and',
-                    ['>=', '{{stat_weapon2_use_count}}.[[period]]', $startPeriod],
-                    ['<', '{{stat_weapon2_use_count}}.[[period]]', $endPeriod],
+                $query->andWhere([
+                    '{{stat_weapon2_use_count_per_month}}.[[year_month]]' =>
+                        intval($match[1], 10) * 100 + intval($match[2], 10),
                 ]);
             } elseif (substr($form->term, 0, 1) === 'v') {
                 if (!$v1 = SplatoonVersion2::findOne(['tag' => substr($form->term, 1)])) {
@@ -289,14 +280,14 @@ class Weapons2Action extends BaseAction
                     ->one();
                 $query->andWhere([
                     '>=',
-                    '{{stat_weapon2_use_count}}.[[period]]',
-                    BattleHelper::calcPeriod2(strtotime($v1->released_at)),
+                    '{{stat_weapon2_use_count_per_month}}.[[year_month]]',
+                    YearMonth::fromDateString($v1->released_at),
                 ]);
                 if ($v2) {
                     $query->andWhere([
                         '<',
-                        '{{stat_weapon2_use_count}}.[[period]]',
-                        BattleHelper::calcPeriod2(strtotime($v2->released_at)),
+                        '{{stat_weapon2_use_count_per_month}}.[[year_month]]',
+                        YearMonth::fromDateString($v2->released_at),
                     ]);
                 }
             } elseif (substr($form->term, 0, 2) === '~v') {
@@ -320,14 +311,14 @@ class Weapons2Action extends BaseAction
                     ->one();
                 $query->andWhere([
                     '>=',
-                    '{{stat_weapon2_use_count}}.[[period]]',
-                    BattleHelper::calcPeriod2(strtotime($v1->released_at)),
+                    '{{stat_weapon2_use_count_per_month}}.[[year_month]]',
+                    YearMonth::fromDateString($v1->released_at),
                 ]);
                 if ($v3) {
                     $query->andWhere([
                         '<',
-                        '{{stat_weapon2_use_count}}.[[period]]',
-                        BattleHelper::calcPeriod2(strtotime($v3->released_at)),
+                        '{{stat_weapon2_use_count_per_month}}.[[year_month]]',
+                        YearMonth::fromDateString($v3->released_at),
                     ]);
                 }
             } else {

--- a/commands/StatController.php
+++ b/commands/StatController.php
@@ -42,6 +42,7 @@ use app\models\StatEntireUser;
 use app\models\StatEntireUser3;
 use app\models\StatWeapon;
 use app\models\StatWeapon2UseCount;
+use app\models\StatWeapon2UseCountPerMonth;
 use app\models\StatWeapon2UseCountPerWeek;
 use app\models\StatWeaponBattleCount;
 use app\models\StatWeaponKDWinRate;
@@ -1434,6 +1435,44 @@ final class StatController extends Controller
         );
         // }}}
 
+        // {{{
+        $yearMonth = "TO_CHAR(PERIOD2_TO_TIMESTAMP({{t}}.[[period]]) AT TIME ZONE 'UTC', 'YYYYMM')::integer";
+        $maxMonth = (int)StatWeapon2UseCountPerMonth::find()->max('[[year_month]]');
+        if ($maxMonth <= 0) {
+            $maxMonth = 201708;
+        }
+        $selectMonth = new Query()
+            ->select(array_merge(
+                [
+                    'year_month' => $yearMonth,
+                    'rule_id' => '{{t}}.[[rule_id]]',
+                    'weapon_id' => '{{t}}.[[weapon_id]]',
+                    'map_id' => '{{t}}.[[map_id]]',
+                ],
+                ArrayHelper::map(
+                    $columns,
+                    fn (string $colName): string => $colName,
+                    fn (string $colName): string => "SUM({{t}}.[[{$colName}]])",
+                ),
+            ))
+            ->from(sprintf('{{%s}} {{t}}', StatWeapon2UseCount::tableName()))
+            ->groupBy([
+                $yearMonth,
+                '{{t}}.[[rule_id]]',
+                '{{t}}.[[weapon_id]]',
+                '{{t}}.[[map_id]]',
+            ])
+            ->having(['>=', $yearMonth, $maxMonth]);
+        $upsertMonth = sprintf(
+            'INSERT INTO {{%s}} ( %s ) %s ON CONFLICT ( %s ) DO UPDATE SET %s',
+            StatWeapon2UseCountPerMonth::tableName(),
+            implode(', ', array_map(fn (string $a): string => "[[{$a}]]", array_keys($selectMonth->select))),
+            $selectMonth->createCommand()->rawSql,
+            implode(', ', array_map(fn (string $a): string => "[[{$a}]]", ['year_month', 'rule_id', 'weapon_id', 'map_id'])),
+            implode(', ', array_map(fn (string $a): string => sprintf('[[%1$s]] = {{excluded}}.[[%1$s]]', $a), $columns)),
+        );
+        // }}}
+
         $transaction = $db->beginTransaction();
         $db->createCommand("SET timezone TO 'Asia/Tokyo'")->execute();
 
@@ -1445,12 +1484,17 @@ final class StatController extends Controller
         $db->createCommand($upsertWeek)->execute();
         echo "\n";
 
+        echo "Executing {$upsertMonth} ...\n";
+        $db->createCommand($upsertMonth)->execute();
+        echo "\n";
+
         echo "Commiting...\n";
         $transaction->commit();
 
         echo "Vacuum...\n";
         $db->createCommand('VACUUM ANALYZE {{stat_weapon2_use_count}}')->execute();
         $db->createCommand('VACUUM ANALYZE {{stat_weapon2_use_count_per_week}}')->execute();
+        $db->createCommand('VACUUM ANALYZE {{stat_weapon2_use_count_per_month}}')->execute();
         // }}}
     }
 

--- a/components/helpers/YearMonth.php
+++ b/components/helpers/YearMonth.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * @copyright Copyright (C) 2017-2026 AIZAWA Hina
+ * @license https://github.com/fetus-hina/stat.ink/blob/master/LICENSE MIT
+ */
+
+declare(strict_types=1);
+
+namespace app\components\helpers;
+
+use DateTimeImmutable;
+use DateTimeInterface;
+use DateTimeZone;
+
+final class YearMonth
+{
+    public static function fromDateString(string $dateString): int
+    {
+        return self::fromDateTime(new DateTimeImmutable($dateString));
+    }
+
+    public static function fromDateTime(DateTimeInterface $dt): int
+    {
+        return (int)(new DateTimeImmutable('@' . $dt->getTimestamp()))
+            ->setTimezone(new DateTimeZone('Etc/UTC'))
+            ->format('Ym');
+    }
+
+    private function __construct()
+    {
+    }
+}

--- a/migrations/m260525_094823_create_stat_weapon2_use_count_per_month.php
+++ b/migrations/m260525_094823_create_stat_weapon2_use_count_per_month.php
@@ -1,0 +1,119 @@
+<?php
+
+/**
+ * @copyright Copyright (C) 2017-2026 AIZAWA Hina
+ * @license https://github.com/fetus-hina/stat.ink/blob/master/LICENSE MIT
+ */
+
+declare(strict_types=1);
+
+use app\components\db\Migration;
+
+final class m260525_094823_create_stat_weapon2_use_count_per_month extends Migration
+{
+    public function safeUp()
+    {
+        $this->createTable('{{%stat_weapon2_use_count_per_month}}', [
+            'year_month' => $this->integer()->notNull(),
+            'rule_id' => $this->pkRef('{{%rule2}}'),
+            'weapon_id' => $this->pkRef('{{%weapon2}}'),
+            'map_id' => $this->pkRef('{{%map2}}'),
+            'battles' => $this->bigInteger()->notNull(),
+            'wins' => $this->bigInteger()->notNull(),
+            'kills' => $this->bigInteger()->notNull(),
+            'deaths' => $this->bigInteger()->notNull(),
+            'kd_available' => $this->bigInteger()->notNull(),
+            'kills_with_time' => $this->bigInteger()->notNull(),
+            'deaths_with_time' => $this->bigInteger()->notNull(),
+            'kd_time_available' => $this->bigInteger()->notNull(),
+            'kd_time_seconds' => $this->bigInteger()->notNull(),
+            'specials' => $this->bigInteger()->notNull(),
+            'specials_available' => $this->bigInteger()->notNull(),
+            'specials_with_time' => $this->bigInteger()->notNull(),
+            'specials_time_available' => $this->bigInteger()->notNull(),
+            'specials_time_seconds' => $this->bigInteger()->notNull(),
+            'inked' => $this->bigInteger()->notNull(),
+            'inked_available' => $this->bigInteger()->notNull(),
+            'inked_with_time' => $this->bigInteger()->notNull(),
+            'inked_time_available' => $this->bigInteger()->notNull(),
+            'inked_time_seconds' => $this->bigInteger()->notNull(),
+            'knockout_wins' => $this->bigInteger()->null(),
+            'timeup_wins' => $this->bigInteger()->null(),
+            'knockout_loses' => $this->bigInteger()->null(),
+            'timeup_loses' => $this->bigInteger()->null(),
+            $this->tablePrimaryKey([
+                'year_month',
+                'rule_id',
+                'weapon_id',
+                'map_id',
+            ]),
+        ]);
+
+        $sumColumns = [
+            'battles',
+            'wins',
+            'kills',
+            'deaths',
+            'kd_available',
+            'kills_with_time',
+            'deaths_with_time',
+            'kd_time_available',
+            'kd_time_seconds',
+            'specials',
+            'specials_available',
+            'specials_with_time',
+            'specials_time_available',
+            'specials_time_seconds',
+            'inked',
+            'inked_available',
+            'inked_with_time',
+            'inked_time_available',
+            'inked_time_seconds',
+            'knockout_wins',
+            'timeup_wins',
+            'knockout_loses',
+            'timeup_loses',
+        ];
+
+        $columns = array_merge(
+            ['year_month', 'rule_id', 'weapon_id', 'map_id'],
+            $sumColumns,
+        );
+
+        $selects = array_merge(
+            [
+                "TO_CHAR(period2_to_timestamp([[period]]) AT TIME ZONE 'UTC', 'YYYYMM')::integer",
+                '[[rule_id]]',
+                '[[weapon_id]]',
+                '[[map_id]]',
+            ],
+            array_map(
+                fn (string $col): string => "SUM([[{$col}]])",
+                $sumColumns,
+            ),
+        );
+
+        $this->execute(vsprintf('INSERT INTO %s ( %s ) SELECT %s FROM %s GROUP BY %s', [
+            $this->db->quoteTableName('{{%stat_weapon2_use_count_per_month}}'),
+            implode(', ', array_map(
+                fn (string $c): string => $this->db->quoteColumnName($c),
+                $columns,
+            )),
+            implode(', ', $selects),
+            $this->db->quoteTableName('{{%stat_weapon2_use_count}}'),
+            implode(', ', ['1', '[[rule_id]]', '[[weapon_id]]', '[[map_id]]']),
+        ]));
+    }
+
+    public function safeDown()
+    {
+        $this->dropTable('{{%stat_weapon2_use_count_per_month}}');
+    }
+
+    protected function vacuumTables(): array
+    {
+        return [
+            '{{%stat_weapon2_use_count_per_month}}',
+        ];
+    }
+}

--- a/models/EntireWeapon2Form.php
+++ b/models/EntireWeapon2Form.php
@@ -23,10 +23,27 @@ use function time;
 use function usort;
 use function version_compare;
 
+use const SORT_DESC;
+
 class EntireWeapon2Form extends Model
 {
     public $term;
     public $map;
+
+    public function init()
+    {
+        parent::init();
+        $this->term = $this->getDefaultTerm();
+    }
+
+    private function getDefaultTerm(): string
+    {
+        $latest = SplatoonVersion2::find()
+            ->orderBy(['released_at' => SORT_DESC])
+            ->limit(1)
+            ->one();
+        return $latest !== null ? 'v' . $latest->tag : '';
+    }
 
     public function formName()
     {
@@ -135,7 +152,11 @@ class EntireWeapon2Form extends Model
         $limit = new DateTimeImmutable()
             ->setTimeZone(new DateTimeZone('Etc/UTC'))
             ->setTimestamp($_SERVER['REQUEST_TIME'] ?? time());
-        $formatter = Yii::$app->formatter;
+        // The keys are UTC year-months (matching stat_weapon2_use_count_per_month.year_month),
+        // so the display labels must be rendered in UTC too — otherwise a user-local timezone
+        // west of UTC would shift midnight back into the previous month.
+        $formatter = clone Yii::$app->formatter;
+        $formatter->timeZone = 'Etc/UTC';
         $result = [];
         for (; $date <= $limit; $date = $date->add($interval)) {
             $result[$date->format('Y-m')] = $formatter->asDate($date, Yii::t('app', 'MMMM y'));

--- a/models/StatWeapon2UseCountPerMonth.php
+++ b/models/StatWeapon2UseCountPerMonth.php
@@ -1,0 +1,149 @@
+<?php
+
+/**
+ * @copyright Copyright (C) 2017-2026 AIZAWA Hina
+ * @license https://github.com/fetus-hina/stat.ink/blob/master/LICENSE MIT
+ */
+
+namespace app\models;
+
+use yii\db\ActiveQuery;
+use yii\db\ActiveRecord;
+
+/**
+ * This is the model class for table "stat_weapon2_use_count_per_month".
+ *
+ * @property integer $year_month
+ * @property integer $rule_id
+ * @property integer $weapon_id
+ * @property integer $map_id
+ * @property integer $battles
+ * @property integer $wins
+ * @property integer $kills
+ * @property integer $deaths
+ * @property integer $kd_available
+ * @property integer $kills_with_time
+ * @property integer $deaths_with_time
+ * @property integer $kd_time_available
+ * @property integer $kd_time_seconds
+ * @property integer $specials
+ * @property integer $specials_available
+ * @property integer $specials_with_time
+ * @property integer $specials_time_available
+ * @property integer $specials_time_seconds
+ * @property integer $inked
+ * @property integer $inked_available
+ * @property integer $inked_with_time
+ * @property integer $inked_time_available
+ * @property integer $inked_time_seconds
+ * @property integer $knockout_wins
+ * @property integer $timeup_wins
+ * @property integer $knockout_loses
+ * @property integer $timeup_loses
+ *
+ * @property Rule2 $rule
+ * @property Weapon2 $weapon
+ * @property Map2 $map
+ */
+class StatWeapon2UseCountPerMonth extends ActiveRecord
+{
+    /**
+     * @inheritdoc
+     */
+    public static function tableName()
+    {
+        return 'stat_weapon2_use_count_per_month';
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function rules()
+    {
+        return [
+            [['year_month', 'rule_id', 'weapon_id', 'map_id', 'battles', 'wins', 'kills', 'deaths'], 'required'],
+            [['kd_available', 'kills_with_time', 'deaths_with_time', 'kd_time_available'], 'required'],
+            [['kd_time_seconds', 'specials', 'specials_available', 'specials_with_time'], 'required'],
+            [['specials_time_available', 'specials_time_seconds', 'inked', 'inked_available'], 'required'],
+            [['inked_with_time', 'inked_time_available', 'inked_time_seconds'], 'required'],
+            [['year_month', 'rule_id', 'weapon_id', 'map_id', 'battles', 'wins', 'kills', 'deaths'], 'integer'],
+            [['kd_available', 'kills_with_time', 'deaths_with_time', 'kd_time_available'], 'integer'],
+            [['kd_time_seconds', 'specials', 'specials_available', 'specials_with_time'], 'integer'],
+            [['specials_time_available', 'specials_time_seconds', 'inked', 'inked_available'], 'integer'],
+            [['inked_with_time', 'inked_time_available', 'inked_time_seconds', 'knockout_wins'], 'integer'],
+            [['timeup_wins', 'knockout_loses', 'timeup_loses'], 'integer'],
+            [['rule_id'], 'exist', 'skipOnError' => true,
+                'targetClass' => Rule2::class,
+                'targetAttribute' => ['rule_id' => 'id'],
+            ],
+            [['weapon_id'], 'exist', 'skipOnError' => true,
+                'targetClass' => Weapon2::class,
+                'targetAttribute' => ['weapon_id' => 'id'],
+            ],
+            [['map_id'], 'exist', 'skipOnError' => true,
+                'targetClass' => Map2::class,
+                'targetAttribute' => ['map_id' => 'id'],
+            ],
+        ];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function attributeLabels()
+    {
+        return [
+            'year_month' => 'Year Month',
+            'rule_id' => 'Rule ID',
+            'weapon_id' => 'Weapon ID',
+            'map_id' => 'Map ID',
+            'battles' => 'Battles',
+            'wins' => 'Wins',
+            'kills' => 'Kills',
+            'deaths' => 'Deaths',
+            'kd_available' => 'Kd Available',
+            'kills_with_time' => 'Kills With Time',
+            'deaths_with_time' => 'Deaths With Time',
+            'kd_time_available' => 'Kd Time Available',
+            'kd_time_seconds' => 'Kd Time Seconds',
+            'specials' => 'Specials',
+            'specials_available' => 'Specials Available',
+            'specials_with_time' => 'Specials With Time',
+            'specials_time_available' => 'Specials Time Available',
+            'specials_time_seconds' => 'Specials Time Seconds',
+            'inked' => 'Inked',
+            'inked_available' => 'Inked Available',
+            'inked_with_time' => 'Inked With Time',
+            'inked_time_available' => 'Inked Time Available',
+            'inked_time_seconds' => 'Inked Time Seconds',
+            'knockout_wins' => 'Knockout Wins',
+            'timeup_wins' => 'Timeup Wins',
+            'knockout_loses' => 'Knockout Loses',
+            'timeup_loses' => 'Timeup Loses',
+        ];
+    }
+
+    /**
+     * @return ActiveQuery
+     */
+    public function getRule()
+    {
+        return $this->hasOne(Rule2::class, ['id' => 'rule_id']);
+    }
+
+    /**
+     * @return ActiveQuery
+     */
+    public function getWeapon()
+    {
+        return $this->hasOne(Weapon2::class, ['id' => 'weapon_id']);
+    }
+
+    /**
+     * @return ActiveQuery
+     */
+    public function getMap()
+    {
+        return $this->hasOne(Map2::class, ['id' => 'map_id']);
+    }
+}

--- a/tests/unit/helpers/YearMonthTest.php
+++ b/tests/unit/helpers/YearMonthTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace tests\helpers;
+
+use Codeception\Test\Unit;
+use DateTimeImmutable;
+use DateTimeZone;
+use app\components\helpers\YearMonth;
+
+final class YearMonthTest extends Unit
+{
+    /**
+     * @dataProvider provideDateStrings
+     */
+    public function testFromDateString(string $input, int $expected): void
+    {
+        $this->assertSame($expected, YearMonth::fromDateString($input));
+    }
+
+    public function provideDateStrings(): array
+    {
+        return [
+            'UTC start of month' => ['2017-07-01T00:00:00+00:00', 201707],
+            'UTC end of month' => ['2017-07-31T23:59:59+00:00', 201707],
+            'JST cross-month boundary backwards' => ['2017-08-01T08:00:00+09:00', 201707],
+            'JST cross-month boundary forwards' => ['2017-08-01T10:00:00+09:00', 201708],
+            'with PostgreSQL +00 offset' => ['2017-07-21 04:00:00+00', 201707],
+            'two-digit year padding' => ['2099-01-01T00:00:00+00:00', 209901],
+        ];
+    }
+
+    public function testFromDateTimeUsesUtcWallClock(): void
+    {
+        $dt = new DateTimeImmutable('2017-08-01T10:00:00', new DateTimeZone('Asia/Tokyo'));
+        $this->assertSame(201708, YearMonth::fromDateTime($dt));
+
+        $dt = new DateTimeImmutable('2017-08-01T08:00:00', new DateTimeZone('Asia/Tokyo'));
+        $this->assertSame(201707, YearMonth::fromDateTime($dt));
+    }
+}


### PR DESCRIPTION
### **User description**
## Summary

The `/entire/weapons2` page used to aggregate the ~6.7 GB
`stat_weapon2_use_count` table on every request, which routinely timed out
and returned 500. Because the page only exposes month- or version-level
filters, the 2-hour-period granularity in the source table was paying ~360x
extra storage and I/O for no user-facing benefit.

This PR:

- Adds `stat_weapon2_use_count_per_month`, keyed by
  `(year_month, rule_id, weapon_id, map_id)`, built off the existing
  per-period source. The new table is ~189 MB (35x smaller) and the page
  now responds in well under 2 s for every filter combination.
- Switches `Weapons2Action` to query the new table. Month filter becomes a
  single integer equality; version filter rounds to month boundaries
  (acceptable since Splatoon 2 has been EOL for years).
- Extends the batch in `StatController` to upsert `per_month` alongside
  `per_period` and `per_week`.
- Defaults the term filter to the most recently released version so the
  first page load shows current data; "Any Time" remains selectable.
- Fixes `EntireWeapon2Form::getMonthList()` to render month labels in UTC
  so users west of UTC no longer see labels shifted one month back
  (e.g. `2023-08` rendered as "July 2023").

Fixes #705.
Fixes #1318.

## Benchmark (production data)

| Scenario | Before | After |
| --- | --- | --- |
| Any Time | 500 (timeout) | 1.40 s |
| Year-Month filter | 500 (timeout) | 0.44 s |
| Map filter | 500 (timeout) | 1.03 s |
| Year-Month + Map | 500 (timeout) | 0.14 s |
| Version filter | 500 (timeout) | 0.10–0.46 s |

## Test plan

- [x] `make check-style-php` (only the changed files) passes
- [x] `vendor/bin/codecept run unit helpers` — 120 tests / 1017 assertions pass, including the new `YearMonthTest`
- [x] Verified `/entire/weapons2` returns HTTP 200 with the default, year-month, map, year-month+map, and version filters on production data
- [x] Verified the term-filter month label renders as `August 2023` for `?filter[term]=2023-08` under `Etc/UTC`, `America/Los_Angeles`, `Asia/Tokyo`, and `Pacific/Honolulu`
- [x] Migration applied to production (vdb2): scan + insert completed in 86 s, new table populated to 767k rows


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- 新しい集計テーブル `stat_weapon2_use_count_per_month` を作成し、ページ読み込みを高速化

- 月次データを使用してバージョンフィルターのパフォーマンスを改善

- フォームの初期表示を最新バージョンに設定しユーザーエクスペリエンスを向上

- タイムゾーン処理を修正し、月ラベルが正しく表示されるように修正


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["stat_weapon2_use_count (旧集計)"] -- "集計変更" --> B["stat_weapon2_use_count_per_month (新集計)"]
  C["Weapons2Action"] -- "クエリ変更" --> B
  D["StatController"] -- "バッチ更新" --> B
  E["EntireWeapon2Form"] -- "初期値設定・タイムゾーン修正" --> F["UI改善"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>Weapons2Action.php</strong><dd><code>集計テーブル参照先を月次データに変更</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fetus-hina/stat.ink/pull/1772/files#diff-796a129fc1458a660bf84d2e266c512408f21e8f85c1426cbdd0c4350c792b4b">+40/-49</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>StatController.php</strong><dd><code>月次集計データ生成処理を追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fetus-hina/stat.ink/pull/1772/files#diff-3bbbbe1d81b4266a1b95ba494aa1c88b4172e9f19f249ff1b0cd38ff35c79a32">+44/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>YearMonth.php</strong><dd><code>日付から年月整数を取得するヘルパークラス追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fetus-hina/stat.ink/pull/1772/files#diff-28cbd7f4e00b78655839b90e93b106a8500c8f343dfb21d0799ca116e9afc619">+33/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>m260525_094823_create_stat_weapon2_use_count_per_month.php</strong><dd><code>月次武器使用回数集計テーブルを作成</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fetus-hina/stat.ink/pull/1772/files#diff-e3b0e5720d48999056f01d6160b16cad757dbca1bb894d9ea8e0e6f4bfc507bf">+119/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>StatWeapon2UseCountPerMonth.php</strong><dd><code>月次武器使用回数モデルを定義</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fetus-hina/stat.ink/pull/1772/files#diff-6eb3c6323d108b0fa226de86d695207381bec95ba7e0726d997e28d44fc568dc">+149/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>EntireWeapon2Form.php</strong><dd><code>初期表示条件とタイムゾーン処理を修正</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fetus-hina/stat.ink/pull/1772/files#diff-914b34b25e38f3e17ec36e55fdc42124cb1143ba4c230044f6d6578a15eb9341">+22/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>YearMonthTest.php</strong><dd><code>年月変換ヘルパーのテストを追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fetus-hina/stat.ink/pull/1772/files#diff-f9d8a4213be07f4019a6f4c5256acee92f02ee5c28135892ca22b1d7b98e0140">+42/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

