### PR TITLE
Fade in battle thumbnails on the top page as they finish loading

### DIFF
--- a/resources/react/components/parts/BattleCard.module.css
+++ b/resources/react/components/parts/BattleCard.module.css
@@ -39,66 +39,33 @@
   content: '';
 }
 
-.mediaHasThumbnail {
+.thumbnail {
+  bottom: 0;
+  filter: blur(8px);
+  left: 0;
+  opacity: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
+  transition: opacity 300ms ease-out, filter 300ms ease-out;
 }
 
-@media (min-width: 768px) {
-  .mediaHasThumbnail {
-    background-image:
-      image-set(var(--thumbnail-sm-1-avif) 1x type('image/avif'), var(--thumbnail-sm-2-avif) 2x type('image/avif'), var(--thumbnail-sm-1-webp) 1x type('image/webp'), var(--thumbnail-sm-2-webp) 2x type('image/webp'), var(--thumbnail-sm-1-jpg) 1x type('image/jpeg'), var(--thumbnail-sm-2-jpg) 2x type('image/jpeg')),
-      var(--thumbnail-fallback),
-      linear-gradient(to bottom, #ddd, #bbb),
-      url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAJAQMAAAAB5D5xAAAAA1BMVEX///+nxBvIAAAAAXRSTlMAQObYZgAAAAlwSFlzAAAOxAAADsQBlSsOGwAAAApJREFUCB1jwA0AABsAAScKbaoAAAAASUVORK5CYII=') !important;
-  }
+.thumbnail img {
+  display: block;
+  height: 100%;
+  object-fit: cover;
+  width: 100%;
 }
 
-@media (min-width: 992px) {
-  .mediaHasThumbnail {
-    background-image:
-      image-set(var(--thumbnail-md-1-avif) 1x type('image/avif'), var(--thumbnail-md-2-avif) 2x type('image/avif'), var(--thumbnail-md-1-webp) 1x type('image/webp'), var(--thumbnail-md-2-webp) 2x type('image/webp'), var(--thumbnail-md-1-jpg) 1x type('image/jpeg'), var(--thumbnail-md-2-jpg) 2x type('image/jpeg')),
-      var(--thumbnail-fallback),
-      linear-gradient(to bottom, #ddd, #bbb),
-      url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAJAQMAAAAB5D5xAAAAA1BMVEX///+nxBvIAAAAAXRSTlMAQObYZgAAAAlwSFlzAAAOxAAADsQBlSsOGwAAAApJREFUCB1jwA0AABsAAScKbaoAAAAASUVORK5CYII=') !important;
-  }
+.thumbnailLoaded {
+  filter: none;
+  opacity: 1;
 }
 
-@media (min-width: 1200px) {
-  .mediaHasThumbnail {
-    background-image:
-      image-set(var(--thumbnail-lg-1-avif) 1x type('image/avif'), var(--thumbnail-lg-2-avif) 2x type('image/avif'), var(--thumbnail-lg-1-webp) 1x type('image/webp'), var(--thumbnail-lg-2-webp) 2x type('image/webp'), var(--thumbnail-lg-1-jpg) 1x type('image/jpeg'), var(--thumbnail-lg-2-jpg) 2x type('image/jpeg')),
-      var(--thumbnail-fallback),
-      linear-gradient(to bottom, #ddd, #bbb),
-      url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAJAQMAAAAB5D5xAAAAA1BMVEX///+nxBvIAAAAAXRSTlMAQObYZgAAAAlwSFlzAAAOxAAADsQBlSsOGwAAAApJREFUCB1jwA0AABsAAScKbaoAAAAASUVORK5CYII=') !important;
-  }
-}
-
-@media (min-width: 768px) {
-  :global(.apple) .mediaHasThumbnail {
-    background-image:
-      image-set(var(--thumbnail-sm-1-avif) 1x, var(--thumbnail-sm-2-avif) 2x),
-      var(--thumbnail-fallback),
-      linear-gradient(to bottom, #ddd, #bbb),
-      url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAJAQMAAAAB5D5xAAAAA1BMVEX///+nxBvIAAAAAXRSTlMAQObYZgAAAAlwSFlzAAAOxAAADsQBlSsOGwAAAApJREFUCB1jwA0AABsAAScKbaoAAAAASUVORK5CYII=') !important;
-  }
-}
-
-@media (min-width: 992px) {
-  :global(.apple) .mediaHasThumbnail {
-    background-image:
-      image-set(var(--thumbnail-md-1-avif) 1x, var(--thumbnail-md-2-avif) 2x),
-      var(--thumbnail-fallback),
-      linear-gradient(to bottom, #ddd, #bbb),
-      url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAJAQMAAAAB5D5xAAAAA1BMVEX///+nxBvIAAAAAXRSTlMAQObYZgAAAAlwSFlzAAAOxAAADsQBlSsOGwAAAApJREFUCB1jwA0AABsAAScKbaoAAAAASUVORK5CYII=') !important;
-  }
-}
-
-@media (min-width: 1200px) {
-  :global(.apple) .mediaHasThumbnail {
-    background-image:
-      image-set(var(--thumbnail-lg-1-avif) 1x, var(--thumbnail-lg-2-avif) 2x),
-      var(--thumbnail-fallback),
-      linear-gradient(to bottom, #ddd, #bbb),
-      url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAJAQMAAAAB5D5xAAAAA1BMVEX///+nxBvIAAAAAXRSTlMAQObYZgAAAAlwSFlzAAAOxAAADsQBlSsOGwAAAApJREFUCB1jwA0AABsAAScKbaoAAAAASUVORK5CYII=') !important;
+@media (prefers-reduced-motion: reduce) {
+  .thumbnail {
+    filter: none;
+    transition: none;
   }
 }
 

--- a/resources/react/components/parts/BattleCard.tsx
+++ b/resources/react/components/parts/BattleCard.tsx
@@ -1,5 +1,6 @@
 import type { Battle, RelTimeTranslations } from '../../types';
 import type { CSSProperties } from 'react';
+import { useState } from 'react';
 import RelTime from './RelTime';
 import classes from './BattleCard.module.css';
 
@@ -10,11 +11,24 @@ const EMPTY_IMAGE_16_BY_9 =
 
 const nbsp = '\u{00a0}';
 
+const THUMBNAIL_SIZES = '(min-width: 1200px) 260.5px, (min-width: 992px) 291.33px, 343px';
+
 function thumbnailUrl (template: string, width: number, height: number, x: number, ext: string) {
   return template
     .replace('<w>', String(Math.floor(width * x)))
     .replace('<h>', String(Math.floor(height * x)))
     .replace(/jpg$/, ext);
+}
+
+function buildThumbnailSrcSet (template: string, ext: string) {
+  return [
+    `${thumbnailUrl(template, 260.50, 146.53, 1, ext)} 260w`,
+    `${thumbnailUrl(template, 260.50, 146.53, 2, ext)} 521w`,
+    `${thumbnailUrl(template, 291.33, 163.86, 1, ext)} 291w`,
+    `${thumbnailUrl(template, 291.33, 163.86, 2, ext)} 582w`,
+    `${thumbnailUrl(template, 343.00, 192.94, 1, ext)} 343w`,
+    `${thumbnailUrl(template, 343.00, 192.94, 2, ext)} 686w`
+  ].join(', ');
 }
 
 interface BattleCardProps {
@@ -25,46 +39,46 @@ interface BattleCardProps {
 
 export default function BattleCard (props: BattleCardProps) {
   const { battle, fallbackImage, reltime } = props;
+  const [thumbnailLoaded, setThumbnailLoaded] = useState(false);
 
   return (
     <div className='col-xs-12 col-sm-6 col-md-4 col-lg-3 mb-2'>
       <div className={[classes.root, classes.outlined].join(' ')}>
         <a href={battle.url} className={classes.link}>
           <div
-            className={
-              [
-                classes.media,
-                classes.media16x9,
-                battle.thumbnail ? classes.mediaHasThumbnail : null
-              ].filter(v => v !== null).join(' ')
-            }
-            style={Object.assign(
-              { backgroundImage: buildBackgroundImages(battle, fallbackImage) },
-              battle.thumbnail
-                ? {
-                    '--thumbnail-lg-1-avif': `url('${thumbnailUrl(battle.thumbnail, 260.50, 146.53, 1, 'avif')}')`,
-                    '--thumbnail-lg-1-jpg': `url('${thumbnailUrl(battle.thumbnail, 260.50, 146.53, 1, 'jpg')}')`,
-                    '--thumbnail-lg-1-webp': `url('${thumbnailUrl(battle.thumbnail, 260.50, 146.53, 1, 'webp')}')`,
-                    '--thumbnail-lg-2-avif': `url('${thumbnailUrl(battle.thumbnail, 260.50, 146.53, 2, 'avif')}')`,
-                    '--thumbnail-lg-2-jpg': `url('${thumbnailUrl(battle.thumbnail, 260.50, 146.53, 2, 'jpg')}')`,
-                    '--thumbnail-lg-2-webp': `url('${thumbnailUrl(battle.thumbnail, 260.50, 146.53, 2, 'webp')}')`,
-                    '--thumbnail-md-1-avif': `url('${thumbnailUrl(battle.thumbnail, 291.33, 163.86, 1, 'avif')}')`,
-                    '--thumbnail-md-1-jpg': `url('${thumbnailUrl(battle.thumbnail, 291.33, 163.86, 1, 'jpg')}')`,
-                    '--thumbnail-md-1-webp': `url('${thumbnailUrl(battle.thumbnail, 291.33, 163.86, 1, 'webp')}')`,
-                    '--thumbnail-md-2-avif': `url('${thumbnailUrl(battle.thumbnail, 291.33, 163.86, 2, 'avif')}')`,
-                    '--thumbnail-md-2-jpg': `url('${thumbnailUrl(battle.thumbnail, 291.33, 163.86, 2, 'jpg')}')`,
-                    '--thumbnail-md-2-webp': `url('${thumbnailUrl(battle.thumbnail, 291.33, 163.86, 2, 'webp')}')`,
-                    '--thumbnail-sm-1-avif': `url('${thumbnailUrl(battle.thumbnail, 343.00, 192.94, 1, 'avif')}')`,
-                    '--thumbnail-sm-1-jpg': `url('${thumbnailUrl(battle.thumbnail, 343.00, 192.94, 1, 'jpg')}')`,
-                    '--thumbnail-sm-1-webp': `url('${thumbnailUrl(battle.thumbnail, 343.00, 192.94, 1, 'webp')}')`,
-                    '--thumbnail-sm-2-avif': `url('${thumbnailUrl(battle.thumbnail, 343.00, 192.94, 2, 'avif')}')`,
-                    '--thumbnail-sm-2-jpg': `url('${thumbnailUrl(battle.thumbnail, 343.00, 192.94, 2, 'jpg')}')`,
-                    '--thumbnail-sm-2-webp': `url('${thumbnailUrl(battle.thumbnail, 343.00, 192.94, 2, 'webp')}')`,
-                    '--thumbnail-fallback': `url('${fallbackImage}')`
-                  }
-                : {}
-            ) as CSSProperties}
+            className={[classes.media, classes.media16x9].join(' ')}
+            style={{
+              backgroundImage: buildBackgroundImages(battle, fallbackImage)
+            } as CSSProperties}
           >
+            {battle.thumbnail
+              ? (
+                <picture
+                  className={[
+                    classes.thumbnail,
+                    thumbnailLoaded ? classes.thumbnailLoaded : null
+                  ].filter(v => v !== null).join(' ')}
+                >
+                  <source
+                    type='image/avif'
+                    sizes={THUMBNAIL_SIZES}
+                    srcSet={buildThumbnailSrcSet(battle.thumbnail, 'avif')}
+                  />
+                  <source
+                    type='image/webp'
+                    sizes={THUMBNAIL_SIZES}
+                    srcSet={buildThumbnailSrcSet(battle.thumbnail, 'webp')}
+                  />
+                  <img
+                    alt=''
+                    decoding='async'
+                    sizes={THUMBNAIL_SIZES}
+                    srcSet={buildThumbnailSrcSet(battle.thumbnail, 'jpg')}
+                    onLoad={() => setThumbnailLoaded(true)}
+                  />
+                </picture>
+                )
+              : null}
             {((battle.mode && battle.mode.icon) || (battle.rule && battle.rule.icon))
               ? (
                 <div className={classes.modeIcons}>
@@ -129,7 +143,7 @@ export default function BattleCard (props: BattleCardProps) {
 
 function buildBackgroundImages (battle: Battle, fallbackImage: string) {
   const results = [];
-  if (battle.image) {
+  if (battle.image && !battle.thumbnail) {
     results.push(`url(${battle.image})`);
   }
   if (battle.stage) {


### PR DESCRIPTION
### **User description**
## Summary
- Render the dynamic battle thumbnail through a `<picture>` overlay (AVIF/WebP/JPEG via `sizes` + `srcset`) instead of the CSS `image-set()` stack inside `BattleCard`.
- Fade the thumbnail in with `opacity` + `filter: blur(8px) -> 0` over 300ms once the underlying `<img>` fires `onLoad`, so the card no longer snaps in abruptly when the slow upstream image generator finally resolves the URL.
- Stage image / static fallback / gradient layers remain visible underneath while the thumbnail is still loading.
- Respects `prefers-reduced-motion: reduce` (blur and transition disabled).
- Side effect: xs viewports (<768px) now also receive AVIF/WebP-optimised thumbnails (previously the `image-set()` rules only kicked in at >=768px, so xs fell back to the original full-size `battle.image`).

## Test plan
- [ ] `make react` builds cleanly.
- [ ] `make check-style-js` and `make check-style-css` pass.
- [ ] Visit the top page; with Network throttling enabled, observe the battle cards fade in with the blur-removal animation rather than popping in.
- [ ] Verify across xs / sm / md / lg breakpoints that the appropriate-sized image is picked (DevTools Network tab).
- [ ] Verify cards with no `thumbnail` (older battles) still render the existing background-image fallback unchanged.
- [ ] With `prefers-reduced-motion: reduce` (OS-level or DevTools emulation), confirm the thumbnail appears without blur/transition.
- [ ] Confirm that mode/rule icon badges and the relative-time chip still render above the thumbnail.


___

### **PR Type**
Enhancement


___

### **Description**
- バトルサムネイルの読み込み完了時にフェードインアニメーションを追加

- `<picture>` 要素と `srcset` を使用して、AVIF/WebP 対応を xs ビューポートにも拡張

- サムネイル読み込み中に背景画像が表示されるように改善

- `prefers-reduced-motion` に対応し、モーションを減らす設定ではアニメーションを無効化


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["BattleCard.tsx"] -- "useState追加" --> B["thumbnailLoaded状態管理"]
  A -- "<picture>要素導入" --> C["サムネイル描画処理"]
  C -- "onLoadイベント" --> B
  D["BattleCard.module.css"] -- "スタイル変更" --> E[".thumbnailクラス追加"]
  E -- "アニメーション定義" --> F["opacity/filter/transition"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BattleCard.tsx</strong><dd><code>サムネイル読み込み状態管理と描画処理の変更</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

resources/react/components/parts/BattleCard.tsx

<ul><li><code>useState</code> を使用してサムネイルの読み込み状態を管理するように変更<br> <li> サムネイル描画に <code><picture></code> 要素を使用し、AVIF/WebP/JPEG の最適化対応<br> <li> <code>srcSet</code> と <code>sizes</code> を用いたレスポンシブ画像対応を実装<br> <li> サムネイル読み込み完了時に <code>onLoad</code> イベントで状態を更新</ul>


</details>


  </td>
  <td><a href="https://github.com/fetus-hina/stat.ink/pull/1773/files#diff-fcc3a754221a83d80722b349f258407cb65a94d6dd47c7d548d70bba7ab419ef">+48/-34</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>BattleCard.module.css</strong><dd><code>サムネイルアニメーションスタイルの追加と変更</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

resources/react/components/parts/BattleCard.module.css

<ul><li>古い <code>image-set</code> を使用した背景画像の定義を削除<br> <li> <code>.thumbnail</code> クラスを新規追加し、フェードイン・ぼかしアニメーションを定義<br> <li> <code>.thumbnailLoaded</code> クラスでアニメーション完了時のスタイルを指定<br> <li> <code>prefers-reduced-motion</code> によるアニメーション無効化をサポート</ul>


</details>


  </td>
  <td><a href="https://github.com/fetus-hina/stat.ink/pull/1773/files#diff-d7322799d6989dd0e03c733b360bbd072e1256ebba44d421ef77af028e2614c9">+21/-54</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

