### PR TITLE
Splatoon 3 v11.2.0

### DIFF
--- a/migrations/m260610_050351_s3_11_2_0.php
+++ b/migrations/m260610_050351_s3_11_2_0.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * @copyright Copyright (C) 2015-2026 AIZAWA Hina
+ * @license https://github.com/fetus-hina/stat.ink/blob/master/LICENSE MIT
+ */
+
+declare(strict_types=1);
+
+use app\components\db\Migration;
+use app\components\db\VersionMigration;
+
+final class m260610_050351_s3_11_2_0 extends Migration
+{
+    use VersionMigration;
+
+    /**
+     * @inheritdoc
+     */
+    #[Override]
+    public function safeUp()
+    {
+        $this->upVersion3(
+            '11.2',
+            'v11.2.x',
+            '11.2.0',
+            'v11.2.0',
+            new DateTimeImmutable('2026-06-11T10:10:00+09:00'),
+        );
+
+        return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    #[Override]
+    public function safeDown()
+    {
+        $this->downVersion3('11.2.0', '11.1.0');
+
+        return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    #[Override]
+    protected function vacuumTables(): array
+    {
+        return [
+            '{{%splatoon_version3}}',
+            '{{%splatoon_version_group3}}',
+        ];
+    }
+}


### PR DESCRIPTION
### **User description**
Add a migration to register Splatoon 3 version 11.2.0 (release scheduled for 2026-06-11 10:10 JST).

Ref: https://support.nintendo.com/jp/switch/software_support/av5ja/1120.html


___

### **PR Type**
Enhancement


___

### **Description**
- Splatoon 3 v11.2.0 のバージョン登録マイグレーションを追加

- リリース日時 2026-06-11 10:10 JST を設定

- ロールバック時は v11.1.0 へ復元


___

### Diagram Walkthrough


```mermaid
flowchart LR
  migration["マイグレーション実行"] --> version["{{%splatoon_version3}} 更新"]
  migration --> group["{{%splatoon_version_group3}} 更新"]
  version --> done["v11.2.0 登録完了"]
  group --> done
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>m260610_050351_s3_11_2_0.php</strong><dd><code>Splatoon 3 v11.2.0 バージョン登録マイグレーション</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

migrations/m260610_050351_s3_11_2_0.php

<ul><li><code>VersionMigration</code> トレイトを使用したマイグレーションクラスを新規作成<br> <li> <code>safeUp()</code> で v11.2.0 を <code>2026-06-11T10:10:00+09:00</code> のリリース日時で登録<br> <li> <code>safeDown()</code> で v11.2.0 を削除し v11.1.0 へロールバック<br> <li> <code>vacuumTables()</code> で <code>{{%splatoon_version3}}</code> と <code>{{%splatoon_version_group3}}</code> <br>を指定</ul>


</details>


  </td>
  <td><a href="https://github.com/fetus-hina/stat.ink/pull/1793/files#diff-5595a89de693c6e1373633ea94009da11f5fa8283d64664c71067c83ffbe5168">+56/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

