### PR TITLE
Update jp3cki/uuid to v6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "guzzlehttp/guzzle": "^7.11.1",
     "jaybizzle/crawler-detect": "^1.3.11",
     "jp3cki/mb_str_replace": "^4.0.2",
-    "jp3cki/uuid": "^5.0.0",
+    "jp3cki/uuid": "^6.0.0",
     "jp3cki/yii2-bs-datetimepicker": "^1.0",
     "jp3cki/yii2-flot": "^1.0",
     "jp3cki/yii2-jquery-color": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "dd416dfbdff7068c563c313a58d83c2b",
+    "content-hash": "e8a562a8def0205c915d05bf4544f534",
     "packages": [
         {
             "name": "cebe/markdown",
@@ -883,16 +883,16 @@
         },
         {
             "name": "jp3cki/uuid",
-            "version": "v5.0.0",
+            "version": "v6.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/fetus-hina/uuid.git",
-                "reference": "0af4149e796cbd7045be3128cd65f06f73fd6b80"
+                "reference": "d2b680fb4edd48fb56f1b8398299114c804e607b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/fetus-hina/uuid/zipball/0af4149e796cbd7045be3128cd65f06f73fd6b80",
-                "reference": "0af4149e796cbd7045be3128cd65f06f73fd6b80",
+                "url": "https://api.github.com/repos/fetus-hina/uuid/zipball/d2b680fb4edd48fb56f1b8398299114c804e607b",
+                "reference": "d2b680fb4edd48fb56f1b8398299114c804e607b",
                 "shasum": ""
             },
             "require": {
@@ -903,10 +903,10 @@
                 "php-64bit": ">= 8.2"
             },
             "require-dev": {
-                "ergebnis/composer-normalize": "^2.48.2",
-                "jp3cki/coding-standard": "^1.0.3",
-                "phpstan/phpstan": "^2.1.32",
-                "phpunit/phpunit": "^11.5.45",
+                "ergebnis/composer-normalize": "^2.52.0",
+                "jp3cki/coding-standard": "^2.0.0",
+                "phpstan/phpstan": "^2.1.56",
+                "phpunit/phpunit": "^11.5.55",
                 "squizlabs/php_codesniffer": "^3.13.5"
             },
             "type": "library",
@@ -928,9 +928,9 @@
             ],
             "support": {
                 "issues": "https://github.com/fetus-hina/uuid/issues",
-                "source": "https://github.com/fetus-hina/uuid/tree/v5.0.0"
+                "source": "https://github.com/fetus-hina/uuid/tree/v6.0.0"
             },
-            "time": "2025-12-02T07:35:09+00:00"
+            "time": "2026-05-28T06:52:37+00:00"
         },
         {
             "name": "jp3cki/yii2-bs-datetimepicker",


### PR DESCRIPTION
### **User description**
## Summary

Bump the `jp3cki/uuid` dependency from `^5.0.0` to `^6.0.0` (a major version update). Only the `jp3cki/uuid` entry changes in `composer.lock`.

## Release notes — v6.0.0 (breaking changes)

- **Stricter `fromString()` / `isValid()` variant validation.** Versions 1–8 must now carry the RFC 4122 variant (`0b10xx`); the Microsoft GUID variant (`0b110x`) is also accepted for .NET/COM interop. NCS (`0b0xxx`) and the reserved variant (`0b111x`) are now **rejected**, whereas v5 checked only the version nibble and silently accepted them.
- **`Uuid::v7()` randomizes `rand_a` per call** from the CSPRNG instead of a process-wide static counter. This drops strict intra-millisecond monotonic ordering (still permitted by RFC 9562 §5.7) while removing the shared state, the 4096/ms wrap hazard, and the cross-request correlation channel. Millisecond-granularity sortability is unchanged.

## Why this major update is safe for stat.ink

- **`Uuid::v7()` is not used** anywhere in the codebase, so the `rand_a` / ordering change has no effect.
- Every `fromString()` / `new Uuid()` input is either a **self-generated v4/v5 UUID** (always RFC 4122 variant → still accepted) or **untrusted external input that is explicitly validated** (battle/salmon URL `id`, blog entry `uuid`). For the latter, rejecting non-RFC4122 / non-MS-GUID variants is the intended, stricter-and-more-correct behavior.
- The **nil UUID (version 0) remains valid**, so WebAuthn AAGUIDs without attestation still convert via `binaryToUuidString()`.
- The **PHP requirement is unchanged** (`>= 8.2`), satisfied by the project's PHP 8.3+ baseline.

## Verification

- `composer update jp3cki/uuid -W` → only `jp3cki/uuid` v5.0.0 → v6.0.0 in `composer.lock`.
- Smoke test on the installed v6: `Uuid::v4()`, `Uuid::v5()`, `fromString()` round-trip, and nil-UUID acceptance all behave as expected.

Ref: https://github.com/fetus-hina/uuid/releases/tag/v6.0.0


___

### **PR Type**
Enhancement


___

### **Description**
- `jp3cki/uuid` を v6 に更新

- 厳格な UUID バリアント検証を導入

- 既存コードへの影響はないと確認


___

### Diagram Walkthrough


```mermaid
flowchart LR
  composer["composer.json"] -- "update dependency" --> uuid["jp3cki/uuid v6"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>composer.json</strong><dd><code>UUID ライブラリのメジャーバージョン更新</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

composer.json

- `jp3cki/uuid` のバージョン要件を `^5.0.0` から `^6.0.0` に更新


</details>


  </td>
  <td><a href="https://github.com/fetus-hina/stat.ink/pull/1799/files#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

