### PR TITLE
Add Salmon Run usage statistics to entire/users page

### DIFF
--- a/actions/entire/UsersAction.php
+++ b/actions/entire/UsersAction.php
@@ -8,6 +8,7 @@
 namespace app\actions\entire;
 
 use Yii;
+use app\actions\entire\users\Salmon3;
 use app\actions\entire\users\Splatoon1;
 use app\actions\entire\users\Splatoon2;
 use app\actions\entire\users\Splatoon3;
@@ -25,6 +26,7 @@ use function usort;
 
 class UsersAction extends Action
 {
+    use Salmon3;
     use Splatoon1;
     use Splatoon2;
     use Splatoon3;
@@ -47,6 +49,7 @@ class UsersAction extends Action
             'posts' => $this->getPostStats(),
             'posts2' => $this->getPostStats2(),
             'posts3' => $this->getPostStats3(),
+            'postsSalmon3' => $this->getPostStatsSalmon3(),
         ]);
     }
 

--- a/actions/entire/users/Salmon3.php
+++ b/actions/entire/users/Salmon3.php
@@ -1,0 +1,81 @@
+<?php
+
+/**
+ * @copyright Copyright (C) 2023-2026 AIZAWA Hina
+ * @license https://github.com/fetus-hina/stat.ink/blob/master/LICENSE MIT
+ */
+
+namespace app\actions\entire\users;
+
+use Yii;
+use app\models\StatEntireSalmon3;
+use yii\db\Connection;
+use yii\db\Query;
+use yii\db\Transaction;
+use yii\helpers\ArrayHelper;
+
+use function count;
+
+use const SORT_ASC;
+
+trait Salmon3
+{
+    protected function getPostStatsSalmon3(): array
+    {
+        return Yii::$app->db->transaction(
+            function (Connection $db): array {
+                $db->createCommand("SET LOCAL TIMEZONE TO 'Etc/UTC'")->execute();
+
+                $lastSummariedDate = null;
+                if ($stats = $this->getPostStatsSummarizedSalmon3($db)) {
+                    $lastSummariedDate = $stats[count($stats) - 1]['date'];
+                } else {
+                    $stats = [];
+                }
+
+                $query = new Query()
+                    ->select([
+                        'date' => '{{%salmon3}}.[[created_at]]::date',
+                        'jobs' => 'COUNT({{%salmon3}}.*)',
+                        'users' => 'COUNT(DISTINCT {{%salmon3}}.[[user_id]])',
+                    ])
+                    ->from('{{%salmon3}}')
+                    ->andWhere(['{{%salmon3}}.[[is_deleted]]' => false])
+                    ->groupBy('{{%salmon3}}.[[created_at]]::date')
+                    ->orderBy(['date' => SORT_ASC]);
+
+                if ($lastSummariedDate) {
+                    $query->andWhere([
+                        '>=',
+                        '{{%salmon3}}.[[created_at]]',
+                        $lastSummariedDate . 'T00:00:00+00:00',
+                    ]);
+                }
+
+                foreach ($query->all($db) as $row) {
+                    $stats[] = $row;
+                }
+
+                return ArrayHelper::getColumn(
+                    $stats,
+                    fn (StatEntireSalmon3|array $model): array => [
+                        'date' => ArrayHelper::getValue($model, 'date'),
+                        'job' => ArrayHelper::getValue($model, 'jobs'),
+                        'user' => ArrayHelper::getValue($model, 'users'),
+                    ],
+                );
+            },
+            Transaction::REPEATABLE_READ,
+        );
+    }
+
+    /**
+     * @return StatEntireSalmon3[]
+     */
+    private function getPostStatsSummarizedSalmon3(Connection $db): array
+    {
+        return StatEntireSalmon3::find()
+            ->orderBy(['date' => SORT_ASC])
+            ->all($db);
+    }
+}

--- a/commands/StatController.php
+++ b/commands/StatController.php
@@ -26,6 +26,7 @@ use app\commands\stat\actions\XPowerDistrib3Action;
 use app\components\helpers\Battle as BattleHelper;
 use app\components\helpers\db\Now;
 use app\models\Battle2;
+use app\models\Battle3;
 use app\models\BattlePlayer;
 use app\models\EventSchedule3;
 use app\models\Knockout;
@@ -35,9 +36,11 @@ use app\models\Mode2;
 use app\models\Rank2;
 use app\models\Rule;
 use app\models\Rule2;
+use app\models\Salmon3;
 use app\models\SplatoonVersion2;
 use app\models\StatAgentUser;
 use app\models\StatAgentUser2;
+use app\models\StatEntireSalmon3;
 use app\models\StatEntireUser;
 use app\models\StatEntireUser3;
 use app\models\StatWeapon;
@@ -355,6 +358,7 @@ final class StatController extends Controller
         $this->updateEntireUser1();
         $this->updateEntireUser2();
         $this->updateEntireUser3();
+        $this->updateEntireSalmonUser3();
     }
 
     private function updateEntireUser1()
@@ -431,8 +435,28 @@ final class StatController extends Controller
     private function updateEntireUser3(): void
     {
         fwrite(STDERR, "Updating stat_entire_user3...\n");
+        $this->upsertEntireUsage3(StatEntireUser3::tableName(), Battle3::tableName(), 'battles');
+    }
+
+    private function updateEntireSalmonUser3(): void
+    {
+        fwrite(STDERR, "Updating stat_entire_salmon3...\n");
+        $this->upsertEntireUsage3(StatEntireSalmon3::tableName(), Salmon3::tableName(), 'jobs');
+    }
+
+    /**
+     * 日別の利用統計 (件数・利用者数) を集計元テーブルから UPSERT する。
+     *
+     * stat_entire_user3 (battle3) と stat_entire_salmon3 (salmon3) で共通の処理。
+     *
+     * @param string $tableName 集計先テーブル (StatEntireUser3::tableName() 等)
+     * @param string $sourceTable 集計元テーブル (Battle3::tableName() 等)
+     * @param string $countColumn 件数を格納するカラム名 (battles / jobs)
+     */
+    private function upsertEntireUsage3(string $tableName, string $sourceTable, string $countColumn): void
+    {
         Yii::$app->db->transaction(
-            function (Connection $db): void {
+            function (Connection $db) use ($tableName, $sourceTable, $countColumn): void {
                 $db->createCommand("SET LOCAL TIMEZONE TO 'Etc/UTC'")->execute();
 
                 $today = new DateTimeImmutable('now', new DateTimeZone('Etc/UTC'))
@@ -442,16 +466,16 @@ final class StatController extends Controller
                 $select = new Query()
                     ->select([
                         'date' => '([[created_at]]::DATE)',
-                        'battles' => 'COUNT(*)',
+                        $countColumn => 'COUNT(*)',
                         'users' => 'COUNT(DISTINCT [[user_id]])',
                     ])
-                    ->from('{{%battle3}}')
+                    ->from($sourceTable)
                     ->andWhere(['is_deleted' => false])
                     ->andWhere(['<', 'created_at', $today->format(DateTimeInterface::ATOM)])
                     ->groupBy(['([[created_at]]::DATE)']);
 
                 $sql = vsprintf('INSERT INTO %s ( %s ) %s ON CONFLICT ( %s ) DO UPDATE SET %s', [
-                    $db->quoteTableName(StatEntireUser3::tableName()),
+                    $db->quoteTableName($tableName),
                     implode(
                         ', ',
                         array_map(

--- a/commands/StatController.php
+++ b/commands/StatController.php
@@ -459,6 +459,7 @@ final class StatController extends Controller
             function (Connection $db) use ($tableName, $sourceTable, $countColumn): void {
                 $db->createCommand("SET LOCAL TIMEZONE TO 'Etc/UTC'")->execute();
 
+                // 今日の 00:00:00 UTC。これより前 (= 昨日まで) を集計対象とする。
                 $today = new DateTimeImmutable('now', new DateTimeZone('Etc/UTC'))
                     ->setTimestamp($_SERVER['REQUEST_TIME'])
                     ->setTime(0, 0, 0);
@@ -473,6 +474,19 @@ final class StatController extends Controller
                     ->andWhere(['is_deleted' => false])
                     ->andWhere(['<', 'created_at', $today->format(DateTimeInterface::ATOM)])
                     ->groupBy(['([[created_at]]::DATE)']);
+
+                // 集計済みの最終日から再集計する (部分更新)。最終日も含めて再集計するため、
+                // 通常は最終日と昨日の 2 日分が更新される。集計済みデータが無い (初回実行)
+                // 場合は下限を設けず、昨日までの全期間を集計する。
+                // 注意: 最終日より古い日のデータが後から削除されても再集計しない。
+                $lastDate = new Query()
+                    ->from($tableName)
+                    ->max('[[date]]', $db);
+                if ($lastDate !== null && $lastDate !== false) {
+                    $from = new DateTimeImmutable($lastDate, new DateTimeZone('Etc/UTC'))
+                        ->setTime(0, 0, 0);
+                    $select->andWhere(['>=', 'created_at', $from->format(DateTimeInterface::ATOM)]);
+                }
 
                 $sql = vsprintf('INSERT INTO %s ( %s ) %s ON CONFLICT ( %s ) DO UPDATE SET %s', [
                     $db->quoteTableName($tableName),

--- a/migrations/m260613_070109_salmon3_created_at.php
+++ b/migrations/m260613_070109_salmon3_created_at.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * @copyright Copyright (C) 2015-2026 AIZAWA Hina
+ * @license https://github.com/fetus-hina/stat.ink/blob/master/LICENSE MIT
+ */
+
+declare(strict_types=1);
+
+use app\components\db\Migration;
+
+final class m260613_070109_salmon3_created_at extends Migration
+{
+    /**
+     * @inheritdoc
+     */
+    #[Override]
+    public function safeUp()
+    {
+        $this->execute(
+            'CREATE INDEX salmon3_created_at ON {{%salmon3}} ([[created_at]]) ' .
+            'WHERE [[is_deleted]] = FALSE',
+        );
+
+        return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    #[Override]
+    public function safeDown()
+    {
+        $this->dropIndex('salmon3_created_at', '{{%salmon3}}');
+
+        return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    #[Override]
+    protected function vacuumTables(): array
+    {
+        return [
+            '{{%salmon3}}',
+        ];
+    }
+}

--- a/views/entire/users.php
+++ b/views/entire/users.php
@@ -56,6 +56,11 @@ FlotTimeAsset::register($this);
     Json::encode($posts3, 0),
     ['id' => 'posts3', 'type' => 'application/json']
   ) . "\n" ?>
+  <?= Html::tag(
+    'script',
+    Json::encode($postsSalmon3, 0),
+    ['id' => 'postsSalmon3', 'type' => 'application/json']
+  ) . "\n" ?>
   <?= Tabs::widget([
     'items' => [
       [
@@ -66,6 +71,15 @@ FlotTimeAsset::register($this);
         ]),
         'content' => $this->render('users/splatoon3', ['agents' => $agents3]),
         'active' => true,
+      ],
+      [
+        'encode' => false,
+        'label' => implode(' ', [
+          Icon::splatoon3(),
+          Html::encode(Yii::t('app-salmon2', 'Salmon Run')),
+        ]),
+        'content' => $this->render('users/salmon3'),
+        'active' => false,
       ],
       [
         'encode' => false,
@@ -109,10 +123,11 @@ $this->registerJs(<<<'EoJS'
     }
 
     var json = JSON.parse($('#' + $graph.attr('data-ref')).text());
+    var countKey = $graph.attr('data-count-key') || 'battle';
     var data = [
       {
         label: '<span class="fa fa-arrow-left"></span>' + $graph.attr('data-label-battle'),
-        data:json.map(function(v){return[dateToUnixTime(v.date),v.battle]}),
+        data:json.map(function(v){return[dateToUnixTime(v.date),v[countKey]]}),
         bars:{
           show:true,
           align: "center",

--- a/views/entire/users/salmon3.php
+++ b/views/entire/users/salmon3.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * @copyright Copyright (C) 2023-2026 AIZAWA Hina
+ * @license https://github.com/fetus-hina/stat.ink/blob/master/LICENSE MIT
+ */
+
+use yii\helpers\Html;
+
+?>
+<?= Html::tag(
+  'div',
+  '',
+  [
+    'class' => 'graph',
+    'data' => [
+      'ref' => 'postsSalmon3',
+      'count-key' => 'job',
+      'label-battle' => Yii::t('app-salmon2', 'Jobs'),
+      'label-user' => Yii::t('app', 'Users'),
+    ],
+  ]
+) . "\n" ?>


### PR DESCRIPTION
### **User description**
## Summary

Salmon Run daily usage statistics were never displayed and the
underlying `stat_entire_salmon3` table was only seeded by its creation
migration, never refreshed afterwards. This adds the aggregation update
and surfaces the data as a new tab on `/entire/users`.

## Changes

### Aggregation (`stat_entire_salmon3`)
- Update `stat_entire_salmon3` from `salmon3` in `actionUpdateEntireUser()`,
  the same place `stat_entire_user3` is updated, by extracting the shared
  UPSERT into `upsertEntireUsage3()`.
- Make the aggregation incremental: instead of re-scanning the whole
  period, aggregate only from the last recorded date through yesterday
  (the last date is re-counted, so normally 2 days are refreshed). On the
  first run (empty table) it falls back to the full period.
- Add a `salmon3(created_at) WHERE is_deleted = FALSE` partial index so
  the narrowed range scan is index-backed (`battle3` already had one).

### Display (`/entire/users`)
- Add a **Salmon Run** tab between the Splatoon 3 and Splatoon 2 tabs.
- The tab shows only the daily jobs/users graph (no recent-client table),
  backed by `stat_entire_salmon3` plus recent live data from `salmon3`,
  mirroring the Splatoon 3 implementation.
- Use the Splatoon 3 icon for the tab.
- Generalize the graph script with a `data-count-key` attribute so it can
  plot jobs; the existing three tabs are unchanged.

## Notes
- Deletion of data older than the last recorded date is intentionally not
  reflected (out of scope, matches the existing user-stats behavior).
- Verified locally: `/entire/users` returns 200, the Salmon Run tab
  renders between Splatoon 3 and 2 with jobs/users data.


___

### **PR Type**
Enhancement


___

### **Description**
- Salmon Runの利用統計を集計・表示

- 増分更新と部分インデックスを追加

- `/entire/users`にSalmon Runタブ追加

- グラフ描画スクリプトを汎用化


___

### Diagram Walkthrough


```mermaid
flowchart LR
  salmon3["salmon3"] -- "incremental aggregation" --> stat["stat_entire_salmon3"]
  battle3["battle3"] -- "shared upsert" --> stat2["stat_entire_user3"]
  stat -- "display" --> tab["Salmon Run Tab"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>UsersAction.php</strong><dd><code>Salmon3トレイト統合と変数追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

actions/entire/UsersAction.php

<ul><li><code>Salmon3</code>トレイトを<code>use</code>し、<code>getPostStatsSalmon3()</code>を呼び出す<br> <li> ビューへ<code>postsSalmon3</code>変数を追加で渡す</ul>


</details>


  </td>
  <td><a href="https://github.com/fetus-hina/stat.ink/pull/1800/files#diff-1d89cae740b9694b7fae6362dd9e8a1d40d658667bba035e5bc769b09e8c28aa">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Salmon3.php</strong><dd><code>Salmon Run利用統計取得トレイト追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

actions/entire/users/Salmon3.php

<ul><li><code>StatEntireSalmon3</code>と<code>salmon3</code>テーブルから日別jobs/usersを集計<br> <li> 最終集計日以降のライブデータを併せて返却</ul>


</details>


  </td>
  <td><a href="https://github.com/fetus-hina/stat.ink/pull/1800/files#diff-2af0c449eaffc17fa6cde25d2cdecb58a20fac3b51d1d806a8d17659a1683d59">+81/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>StatController.php</strong><dd><code>共通UPSERTと増分更新の実装</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

commands/StatController.php

<ul><br><li><code>updateEntireUser3()</code>と<code>updateEntireSalmonUser3()</code>で共通UPSERTを<code>upsertEntireUsage3()</code>に抽出<br> <li> 最終集計日から昨日までの増分更新を実装<br> <li> <code>actionUpdateEntireUser()</code>に<code>salmon3</code>集計を追加</ul>


</details>


  </td>
  <td><a href="https://github.com/fetus-hina/stat.ink/pull/1800/files#diff-3bbbbe1d81b4266a1b95ba494aa1c88b4172e9f19f249ff1b0cd38ff35c79a32">+42/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>m260613_070109_salmon3_created_at.php</strong><dd><code>salmon3部分インデックス追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

migrations/m260613_070109_salmon3_created_at.php

<ul><li><code>salmon3</code>テーブルに<code>created_at</code>の部分インデックスを新規作成<br> <li> <code>is_deleted = FALSE</code>の行のみを対象とする</ul>


</details>


  </td>
  <td><a href="https://github.com/fetus-hina/stat.ink/pull/1800/files#diff-73ad3ea3c02bb83503cec5a823a504037c51fc8cf036e7c1a6ed47915a96ebb2">+49/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>users.php</strong><dd><code>Salmon Runタブ追加とグラフ汎用化</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

views/entire/users.php

<ul><li>Salmon RunタブをSplatoon 3と2の間に新規追加<br> <li> グラフ描画スクリプトを<code>data-count-key</code>属性で汎用化<br> <li> <code>postsSalmon3</code>のJSONデータ埋め込みを追加</ul>


</details>


  </td>
  <td><a href="https://github.com/fetus-hina/stat.ink/pull/1800/files#diff-86b3e573191598689bb11bb01e3b8a11c9c7ed7f0f705bc84e6d17ccfcf487ad">+16/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>salmon3.php</strong><dd><code>Salmon Runグラフビュー新規作成</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

views/entire/users/salmon3.php

<ul><li>Salmon Runタブ専用のグラフ表示ビューを新規作成<br> <li> <code>data-count-key="job"</code>を指定してjobsグラフを描画</ul>


</details>


  </td>
  <td><a href="https://github.com/fetus-hina/stat.ink/pull/1800/files#diff-a105b761e1411edb79147ad21b08c92cda6fc96e928c0177c303de34b443ee1d">+23/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

