### PR TITLE
Include the played-with filter in the permalink

### DIFF
--- a/models/battle3FilterForm/PermalinkTrait.php
+++ b/models/battle3FilterForm/PermalinkTrait.php
@@ -49,6 +49,8 @@ trait PermalinkTrait
             'weapon',
             'result',
             'knockout',
+            'played_with',
+            'played_with_side',
         ];
         foreach ($copyKeys as $key) {
             $value = trim((string)$this->$key);


### PR DESCRIPTION
### **User description**
## Summary

`played_with` (and the newly added `played_with_side`) were missing from the `toPermLink()` copy list in `PermalinkTrait`, so the played-with filter was silently dropped when building a permalink / shared link.

## Changes

- Add `played_with` and `played_with_side` to the `$copyKeys` whitelist in `models/battle3FilterForm/PermalinkTrait.php`.

Both ride on the existing empty-value skip logic, so an unset side produces no extra query parameter.

## Notes

- `php -l` and `phpcs` pass.
- Verified `toPermLink()` output: with a side it emits both `f[played_with]` and `f[played_with_side]`; with an empty side it emits only `f[played_with]`.


___

### **PR Type**
Bug fix


___

### **Description**
- `played_with` と `played_with_side` を `$copyKeys` に追加

- パーマリンク生成時のフィルター欠落を修正

- 空値は既存スキップロジックで対応


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["PermalinkTrait"] -- "toPermLink()" --> B["copyKeys whitelist"]
  B -- "add played_with" --> C["Complete Permalink"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PermalinkTrait.php</strong><dd><code>パーマリンクにプレイ済みフィルターを追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

models/battle3FilterForm/PermalinkTrait.php

<ul><li><code>played_with</code> と <code>played_with_side</code> を <code>$copyKeys</code> 配列に追加<br> <li> パーマリンク生成時にフィルター値が欠落しないよう修正<br> <li> 空値は既存の <code>trim</code> チェックにより自動的にスキップ</ul>


</details>


  </td>
  <td><a href="https://github.com/fetus-hina/stat.ink/pull/1807/files#diff-ff1332d1647984634134a70e9f839adc80c65debebf092ef3876d0b2e72f4f84">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

