### PR TITLE
Add teammate/opponent counts to Battle3 played-with

### DIFF
--- a/components/helpers/userPlayedWith3/UpdateTrait.php
+++ b/components/helpers/userPlayedWith3/UpdateTrait.php
@@ -46,6 +46,35 @@ trait UpdateTrait
             '{{p1}}.[[number]]',
         ]);
 
+        // In a tricolor battle, the role (attacker / defender) of the team the
+        // played-with player belongs to. Our own team is always team 1, so its
+        // role is our_team_role_id. Kept in sync with the played_with_side
+        // filter in battle3FilterForm/QueryDecoratorTrait.
+        $tricolorTeamRole = vsprintf('CASE %s WHEN 1 THEN %s WHEN 2 THEN %s WHEN 3 THEN %s END', [
+            '{{p2}}.[[team]]',
+            '{{%battle3}}.[[our_team_role_id]]',
+            '{{%battle3}}.[[their_team_role_id]]',
+            '{{%battle3}}.[[third_team_role_id]]',
+        ]);
+
+        // Allies share our team's role. This intentionally treats the other
+        // attacking team as an ally when we are on the attacking side, even
+        // though it is a different camp.
+        $isTeammate = vsprintf('(%s) OR (%s)', [
+            '{{p1}}.[[id]] IS NOT NULL AND {{p1}}.[[is_our_team]] = TRUE',
+            vsprintf('{{p2}}.[[id]] IS NOT NULL AND (%s) = %s', [
+                $tricolorTeamRole,
+                '{{%battle3}}.[[our_team_role_id]]',
+            ]),
+        ]);
+        $isOpponent = vsprintf('(%s) OR (%s)', [
+            '{{p1}}.[[id]] IS NOT NULL AND {{p1}}.[[is_our_team]] = FALSE',
+            vsprintf('{{p2}}.[[id]] IS NOT NULL AND (%s) <> %s', [
+                $tricolorTeamRole,
+                '{{%battle3}}.[[our_team_role_id]]',
+            ]),
+        ]);
+
         $select = new Query()
             ->select([
                 'user_id' => '{{%battle3}}.[[user_id]]',
@@ -64,6 +93,8 @@ trait UpdateTrait
                         '({{p1}}.[[id]] IS NOT NULL AND {{p2}}.[[is_disconnected]])',
                     ]),
                 ]),
+                'count_teammate' => vsprintf('SUM(CASE WHEN %s THEN 1 ELSE 0 END)', [$isTeammate]),
+                'count_opponent' => vsprintf('SUM(CASE WHEN %s THEN 1 ELSE 0 END)', [$isOpponent]),
             ])
             ->from('{{%battle3}}')
             ->leftJoin(
@@ -148,7 +179,7 @@ trait UpdateTrait
                 ', ',
                 array_map(
                     fn (string $name): string => sprintf('%1$s = EXCLUDED.%1$s', $db->quoteColumnName($name)),
-                    ['count', 'disconnect'],
+                    ['count', 'disconnect', 'count_teammate', 'count_opponent'],
                 ),
             ),
         ]);

--- a/migrations/m260620_031724_battle3_played_with_side_counts.php
+++ b/migrations/m260620_031724_battle3_played_with_side_counts.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * @copyright Copyright (C) 2015-2026 AIZAWA Hina
+ * @license https://github.com/fetus-hina/stat.ink/blob/master/LICENSE MIT
+ */
+
+declare(strict_types=1);
+
+use app\components\db\Migration;
+
+final class m260620_031724_battle3_played_with_side_counts extends Migration
+{
+    /**
+     * @inheritdoc
+     */
+    public function safeUp()
+    {
+        $this->addColumns('{{%battle3_played_with}}', [
+            'count_teammate' => $this->bigInteger()->null(),
+            'count_opponent' => $this->bigInteger()->null(),
+        ]);
+
+        return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function safeDown()
+    {
+        $this->dropColumns('{{%battle3_played_with}}', [
+            'count_opponent',
+            'count_teammate',
+        ]);
+
+        return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function vacuumTables(): array
+    {
+        return [
+            '{{%battle3_played_with}}',
+        ];
+    }
+}

--- a/models/Battle3PlayedWith.php
+++ b/models/Battle3PlayedWith.php
@@ -22,6 +22,8 @@ use yii\db\ActiveRecord;
  * @property string $ref_id
  * @property integer $count
  * @property integer $disconnect
+ * @property integer|null $count_teammate
+ * @property integer|null $count_opponent
  *
  * @property User $user
  */
@@ -38,7 +40,7 @@ class Battle3PlayedWith extends ActiveRecord
         return [
             [['user_id', 'name', 'number', 'ref_id', 'count', 'disconnect'], 'required'],
             [['user_id', 'count', 'disconnect'], 'default', 'value' => null],
-            [['user_id', 'count', 'disconnect'], 'integer'],
+            [['user_id', 'count', 'disconnect', 'count_teammate', 'count_opponent'], 'integer'],
             [['name'], 'string', 'max' => 10],
             [['number', 'ref_id'], 'string', 'max' => 32],
             [['user_id', 'ref_id'], 'unique', 'targetAttribute' => ['user_id', 'ref_id']],
@@ -57,6 +59,8 @@ class Battle3PlayedWith extends ActiveRecord
             'ref_id' => 'Ref ID',
             'count' => 'Count',
             'disconnect' => 'Disconnect',
+            'count_teammate' => 'Count Teammate',
+            'count_opponent' => 'Count Opponent',
         ];
     }
 

--- a/models/battle3FilterForm/dropdownList/PlayedWithDropdownListTrait.php
+++ b/models/battle3FilterForm/dropdownList/PlayedWithDropdownListTrait.php
@@ -66,10 +66,19 @@ trait PlayedWithDropdownListTrait
 
     private static function formatPlayedWithName(Battle3PlayedWith $model): string
     {
+        $formatter = Yii::$app->formatter;
+        $count = $formatter->asInteger($model->count);
+        if ($model->count_teammate !== null && $model->count_opponent !== null) {
+            $count .= vsprintf(' [%s + %s]', [
+                $formatter->asInteger($model->count_teammate),
+                $formatter->asInteger($model->count_opponent),
+            ]);
+        }
+
         return vsprintf('%s #%s (×%s)', [
             $model->name,
             $model->number,
-            Yii::$app->formatter->asInteger($model->count),
+            $count,
         ]);
     }
 }


### PR DESCRIPTION
### **User description**
## Summary

Adds per-player teammate/opponent breakdown to the Battle3 played-with aggregation, alongside the existing total count.

- New nullable `bigint` columns `count_teammate` / `count_opponent` on `battle3_played_with`.
- The side is determined the same way as the `played_with_side` filter added earlier: for normal battles from `battle_player3.is_our_team`, and for tricolor battles from the role (attacker / defender) of the team the player belongs to, compared against our own team role. This intentionally treats the other attacking team as a teammate when we are on the attacking side.
- Columns are filled in by the same `INSERT ... ON CONFLICT DO UPDATE` path, so existing rows populate as each player is recomputed on the next battle import or a full `user-played-with3/rebuild-battle`.
- The played-with filter dropdown shows the breakdown inside the count parentheses, e.g. `Player #4822 (×162 [162 + 0])`, only when the new columns are non-null.

## Notes

- Salmon (`salmon3_played_with`) is intentionally left unchanged — co-op has no opponent concept.
- `count_teammate + count_opponent <= count`: in tricolor battles with an undetermined role the player counts toward neither side, so the two do not always sum to the total. Both values are stored independently rather than derived.

## Test plan

- [x] Migration applies/reverts cleanly (single `ALTER TABLE` via `addColumns`/`dropColumns`).
- [x] `user-played-with3/rebuild-battle` recomputes values; verified no row violates `count_teammate + count_opponent <= count` and totals match `count` on data without undetermined-role tricolors.
- [x] phpcs passes on changed files.


___

### **PR Type**
Enhancement


___

### **Description**
- `battle3_played_with` に `count_teammate` / `count_opponent` を追加

- 通常/トリカラバトルで味方・敵を判定して集計

- プレイ済みフィルタのドロップダウンに内訳を表示

- 既存行は次回インポートまたは再構築時に更新


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Battle3 Import / Rebuild"] --> B{"Side Determination"}
  B -->|"is_our_team / role match"| C["count_teammate"]
  B -->|"opposite"| D["count_opponent"]
  C --> E["battle3_played_with"]
  D --> E
  E --> F["Dropdown Display"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>UpdateTrait.php</strong><dd><code>味方/敵判定ロジックと集計追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

components/helpers/userPlayedWith3/UpdateTrait.php

<ul><li>トリカラロール比較と <code>is_our_team</code> で味方/敵を判定するSQL式を追加<br> <li> <code>count_teammate</code> と <code>count_opponent</code> の集計を <code>SELECT</code> 句に追加<br> <li> <code>INSERT ... ON CONFLICT DO UPDATE</code> の更新対象列に新カラムを追加</ul>


</details>


  </td>
  <td><a href="https://github.com/fetus-hina/stat.ink/pull/1809/files#diff-493ed845d549dd995b95792be340a188fe2851279eca6fc70f1262a4a3e99806">+32/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Battle3PlayedWith.php</strong><dd><code>モデルに新カラムの定義を追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

models/Battle3PlayedWith.php

<ul><li>PHPDoc に <code>count_teammate</code> と <code>count_opponent</code> のプロパティを追加<br> <li> <code>rules()</code> のバリデーション対象に新カラムを追加<br> <li> <code>attributeLabels()</code> に新カラムのラベルを追加</ul>


</details>


  </td>
  <td><a href="https://github.com/fetus-hina/stat.ink/pull/1809/files#diff-1c915b305cd53658dbfc5507b2ea0423a7ce04e92bd63ef8309e7476924ad3f8">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>PlayedWithDropdownListTrait.php</strong><dd><code>ドロップダウンに味方/敵内訳を表示</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

models/battle3FilterForm/dropdownList/PlayedWithDropdownListTrait.php

<ul><li><code>count_teammate</code> と <code>count_opponent</code> が非nullの場合、カウント表示に <code>[味方 + 敵]</code> の内訳を追加<br> <li> <code>formatPlayedWithName()</code> メソッド内で表示フォーマットを更新</ul>


</details>


  </td>
  <td><a href="https://github.com/fetus-hina/stat.ink/pull/1809/files#diff-8f14fa3da51f8b0574ca9cc7265f1fdeca38c835f73ba9d8cc602ac0f5404f72">+10/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>m260620_031724_battle3_played_with_side_counts.php</strong><dd><code>味方/敵カウント列のマイグレーション追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

migrations/m260620_031724_battle3_played_with_side_counts.php

<ul><li><code>battle3_played_with</code> に <code>count_teammate</code> / <code>count_opponent</code> の nullable <br>bigint 列を追加<br> <li> <code>safeDown</code> で両列を削除<br> <li> <code>vacuumTables</code> で対象テーブルを指定</ul>


</details>


  </td>
  <td><a href="https://github.com/fetus-hina/stat.ink/pull/1809/files#diff-9a4d81a7b6fb8e3476a98eae4c96e480b43402d54457cb691fc23905ae435b58">+49/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

