### PR TITLE
Fix label for `Wave::$power_egg_collected`

### DIFF
--- a/models/api/v2/salmon/Wave.php
+++ b/models/api/v2/salmon/Wave.php
@@ -75,7 +75,7 @@ class Wave extends Model
             'golden_egg_quota' => Yii::t('app-salmon2', 'Golden Egg quota'),
             'golden_egg_appearances' => Yii::t('app-salmon2', 'Golden Egg appearances'),
             'golden_egg_delivered' => Yii::t('app-salmon2', 'Golden Egg delivered'),
-            'power_egg_collected ' => Yii::t('app-salmon2', 'Power Egg collected'),
+            'power_egg_collected' => Yii::t('app-salmon2', 'Power Egg collected'),
         ];
     }
 


### PR DESCRIPTION
I was testing my new PHPStan extension [mspirkov/yii2-phpstan-rules](https://github.com/mspirkov/yii2-phpstan-rules) on your project and found this error 🙂

<img width="892" height="156" alt="image" src="https://github.com/user-attachments/assets/803292d5-c7f3-42c3-9c18-dd037424a74f" />
